### PR TITLE
Downgrade static plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "fastify": "^4.22.2",
-    "@fastify/static": "^8.1.1"
+    "@fastify/static": "^7.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- use `@fastify/static` 7.x compatible with Fastify 4

## Testing
- `npm start` *(fails: Cannot find module 'glob')*
- `npm install` *(fails due to network)*