### PR TITLE
Add delete form to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Außerdem steht ein Formular **Key freigeben** bereit. Mit Eingabe einer ID
 schickt es einen PUT-Request auf `/keys/:id/release`, markiert den Key damit als
 frei und zeigt die Antwort direkt unter dem Formular an.
 
+Neu hinzugekommen ist ein weiteres Formular **Key löschen**, das eine
+ID entgegennimmt und damit einen `DELETE`-Request auf `/keys/:id` ausführt.
+Das Ergebnis wird ebenfalls im Dashboard angezeigt.
+
 
 ## REST-Endpunkte
 
@@ -84,6 +88,9 @@ Die Antwort enthält das aktualisierte Key-Objekt. Bei unbekannter ID wird ein 4
 
 ### PUT `/keys/:id/release`
 Setzt einen zuvor belegten Key wieder auf frei. `inUse` wird dabei auf `false` gesetzt und das Feld `assignedTo` geleert. In der History wird ein Eintrag mit der Aktion `release` und Zeitstempel gespeichert. Die Antwort enthält den aktualisierten Key.
+
+### DELETE `/keys/:id`
+Entfernt einen Key dauerhaft aus der Datenbank. Bei Erfolg wird `{ success: true }` zurückgegeben. Ist die ID unbekannt, lautet der Statuscode `404`.
 
 ## Datenstruktur
 

--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -309,4 +309,33 @@ describe('Key Server API', () => {
 
     await app.close();
   });
+
+  test('Dashboard deleteKey flow via fetch', async () => {
+    const { app } = await createServer();
+
+    // Server auf zuf\xC3\xA4lligem Port starten, um echte HTTP-Aufrufe zu simulieren
+    const address = await app.listen({ port: 0, host: '127.0.0.1' });
+    const port = app.server.address().port;
+
+    // Key anlegen, der anschlie\xC3\x9Fend gel\xC3\xB6scht werden soll
+    const create = await fetch(`http://127.0.0.1:${port}/keys`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: 'ZZZZZ-ZZZZZ-ZZZZZ-ZZZZZ-00001' })
+    });
+    const created = (await create.json())[0];
+
+    // L\xC3\xB6schen wie im Dashboard
+    const del = await fetch(`http://127.0.0.1:${port}/keys/${created.id}`, { method: 'DELETE' });
+    const data = await del.json();
+
+    expect(data.success).toBe(true);
+
+    // Sicherstellen, dass der Key wirklich entfernt wurde
+    const list = await fetch(`http://127.0.0.1:${port}/keys`);
+    const arr = await list.json();
+    expect(arr).toHaveLength(0);
+
+    await app.close();
+  });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -69,6 +69,15 @@
   </section>
 
   <section>
+    <h2>Key l\xC3\xB6schen</h2>
+    <form id="deleteForm">
+      <input type="number" id="deleteId" placeholder="ID" required />
+      <button type="submit">L\xC3\xB6schen</button>
+    </form>
+    <pre id="deleteResult"></pre>
+  </section>
+
+  <section>
     <h2>Log</h2>
     <pre id="historyLog"></pre>
   </section>
@@ -176,6 +185,25 @@
       e.preventDefault();
       const id = document.getElementById('releaseId').value;
       await releaseKey(id);
+    });
+
+    // L\xC3\xB6scht einen Key permanent vom Server
+    async function deleteKey(id) {
+      const res = await fetch(`/keys/${id}`, { method: 'DELETE' });
+      const data = await res.json();
+      document.getElementById('deleteResult').textContent = JSON.stringify(data, null, 2);
+      updateStats();
+      loadFreeList();
+      loadActiveList();
+      // Nach dem L\xC3\xB6schen ist keine Historie mehr vorhanden
+      document.getElementById('historyLog').textContent = '';
+      return data;
+    }
+
+    document.getElementById('deleteForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const id = document.getElementById('deleteId').value;
+      await deleteKey(id);
     });
 
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- extend dashboard with delete key form
- call DELETE /keys/:id via new JS function
- cover dashboard deletion with jest test
- document delete feature in README

## Testing
- `npm test`