### PR TITLE
Add dashboard invalidation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Außerdem steht ein Formular **Key freigeben** bereit. Mit Eingabe einer ID
 schickt es einen PUT-Request auf `/keys/:id/release`, markiert den Key damit als
 frei und zeigt die Antwort direkt unter dem Formular an.
 
+Ebenfalls neu ist ein Formular **Key ungültig**. Gibt man dort eine ID ein,
+wird ein PUT-Request auf `/keys/:id/invalidate` ausgelöst. Der gewählte Key wird
+dadurch dauerhaft als ungültig markiert und das Ergebnis unter dem Formular
+angezeigt.
+
 
 ## REST-Endpunkte
 
@@ -84,6 +89,9 @@ Die Antwort enthält das aktualisierte Key-Objekt. Bei unbekannter ID wird ein 4
 
 ### PUT `/keys/:id/release`
 Setzt einen zuvor belegten Key wieder auf frei. `inUse` wird dabei auf `false` gesetzt und das Feld `assignedTo` geleert. In der History wird ein Eintrag mit der Aktion `release` und Zeitstempel gespeichert. Die Antwort enthält den aktualisierten Key.
+
+### PUT `/keys/:id/invalidate`
+Markiert einen Key dauerhaft als ungültig. Ungültige Keys werden nicht mehr über `/keys/free` ausgegeben. Die Antwort enthält den aktualisierten Datensatz.
 
 ## Datenstruktur
 

--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -309,4 +309,28 @@ describe('Key Server API', () => {
 
     await app.close();
   });
+
+  test('Dashboard invalidateKey flow via fetch', async () => {
+    const { app } = await createServer();
+
+    // Server auf zufälligem Port starten, um echte HTTP-Aufrufe zu simulieren
+    const address = await app.listen({ port: 0, host: '127.0.0.1' });
+    const port = app.server.address().port;
+
+    // Neuen Key anlegen
+    const create = await fetch(`http://127.0.0.1:${port}/keys`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: 'FFFFF-FFFFF-FFFFF-FFFFF-00002' })
+    });
+    const created = (await create.json())[0];
+
+    // Ablauf wie im Dashboard: Key als ungültig markieren
+    const inv = await fetch(`http://127.0.0.1:${port}/keys/${created.id}/invalidate`, { method: 'PUT' });
+    const data = await inv.json();
+
+    expect(data.invalid).toBe(true);
+
+    await app.close();
+  });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -69,6 +69,15 @@
   </section>
 
   <section>
+    <h2>Key ungültig</h2>
+    <form id="invalidateForm">
+      <input type="number" id="invalidateId" placeholder="ID" required />
+      <button type="submit">Key ungültig</button>
+    </form>
+    <pre id="invalidateResult"></pre>
+  </section>
+
+  <section>
     <h2>Log</h2>
     <pre id="historyLog"></pre>
   </section>
@@ -172,10 +181,28 @@
       return data;
     }
 
+    // Markiert einen Key dauerhaft als ungültig
+    async function invalidateKey(id) {
+      const res = await fetch(`/keys/${id}/invalidate`, { method: 'PUT' });
+      const data = await res.json();
+      document.getElementById('invalidateResult').textContent = JSON.stringify(data, null, 2);
+      updateStats();
+      loadFreeList();
+      loadActiveList();
+      showHistory(id);
+      return data;
+    }
+
     document.getElementById('releaseForm').addEventListener('submit', async (e) => {
       e.preventDefault();
       const id = document.getElementById('releaseId').value;
       await releaseKey(id);
+    });
+
+    document.getElementById('invalidateForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const id = document.getElementById('invalidateId').value;
+      await invalidateKey(id);
     });
 
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- add dashboard form to invalidate keys
- implement JS logic for PUT /keys/:id/invalidate
- test dashboard invalidate flow using fetch
- document new form and endpoint

## Testing
- `npm test`