### PR TITLE
Key invalidation via dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Neu hinzugekommen ist ein weiteres Formular **Key löschen**, das eine
 ID entgegennimmt und damit einen `DELETE`-Request auf `/keys/:id` ausführt.
 Das Ergebnis wird ebenfalls im Dashboard angezeigt.
 
+Ebenfalls verfügbar ist nun ein Formular **Key ungültig**, das eine ID annimmt
+und per Button einen `PUT`-Request auf `/keys/:id/invalidate` sendet. Dadurch
+wird der gewählte Key dauerhaft als unbrauchbar markiert. Die Serverantwort wird
+unter dem Formular dargestellt.
+
 
 ## REST-Endpunkte
 
@@ -99,6 +104,11 @@ Die Antwort enthält das aktualisierte Key-Objekt. Bei unbekannter ID wird ein 4
 
 ### PUT `/keys/:id/release`
 Setzt einen zuvor belegten Key wieder auf frei. `inUse` wird dabei auf `false` gesetzt und das Feld `assignedTo` geleert. In der History wird ein Eintrag mit der Aktion `release` und Zeitstempel gespeichert. Die Antwort enthält den aktualisierten Key.
+
+### PUT `/keys/:id/invalidate`
+Markiert einen bestehenden Key dauerhaft als ungültig. Ein so gekennzeichneter
+Eintrag wird von `/keys/free` ignoriert und kann nicht mehr genutzt werden. Die
+Antwort enthält das aktualisierte Key-Objekt mit dem Feld `invalid=true`.
 
 ### DELETE `/keys/:id`
 Entfernt einen Key dauerhaft aus der Datenbank. Bei Erfolg wird `{ success: true }` zurückgegeben. Ist die ID unbekannt, lautet der Statuscode `404`.

--- a/public/index.html
+++ b/public/index.html
@@ -71,6 +71,15 @@
   </section>
 
   <section>
+    <h2>Key ungültig markieren</h2>
+    <form id="invalidateForm">
+      <input type="number" id="invalidateId" placeholder="ID" required />
+      <button type="submit">Key ungültig</button>
+    </form>
+    <pre id="invalidateResult"></pre>
+  </section>
+
+  <section>
     <h2>Key l\xC3\xB6schen</h2>
     <form id="deleteForm">
       <input type="number" id="deleteId" placeholder="ID" required />
@@ -195,6 +204,24 @@
       e.preventDefault();
       const id = document.getElementById('releaseId').value;
       await releaseKey(id);
+    });
+
+    // Markiert einen Key als ungültig
+    async function invalidateKey(id) {
+      const res = await fetch(`/keys/${id}/invalidate`, { method: 'PUT' });
+      const data = await res.json();
+      document.getElementById('invalidateResult').textContent = JSON.stringify(data, null, 2);
+      updateStats();
+      loadFreeList();
+      loadActiveList();
+      showHistory(id);
+      return data;
+    }
+
+    document.getElementById('invalidateForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const id = document.getElementById('invalidateId').value;
+      await invalidateKey(id);
     });
 
     // L\xC3\xB6scht einen Key permanent vom Server

--- a/server.js
+++ b/server.js
@@ -196,6 +196,8 @@ async function buildServer(options = {}) {
     return keyEntry.history || [];
   });
 
+  // Markiert einen Key dauerhaft als ungültig
+  // Im Dashboard wird dieser Endpunkt über den Button "Key ungültig" aufgerufen
   app.put('/keys/:id/invalidate', async (request, reply) => {
     const id = parseInt(request.params.id, 10);
     const keyEntry = keys.find((k) => k.id === id);
@@ -203,6 +205,7 @@ async function buildServer(options = {}) {
       reply.code(404);
       return { error: 'Key nicht gefunden' };
     }
+    // Flag setzen, damit dieser Key künftig nicht mehr verwendet wird
     keyEntry.invalid = true;
     await saveData();
     return keyEntry;


### PR DESCRIPTION
## Summary
- add dashboard form and JS handler for invalidating a key
- document new functionality and endpoint
- test invalidate flow through dashboard
- comment invalidate endpoint

## Testing
- `npm test`