### PR TITLE
Improve dashboard UI with tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ nutzen. Dort werden nun zusätzlich Listen aller freien und aller aktuell
 benutzten Keys angezeigt. Diese Daten stammen aus den Endpunkten
 `/keys/free/list` und `/keys/active/list`.
 Das Layout verwendet nun eine eigene CSS-Datei `public/style.css`, die dem Dashboard ein moderneres Erscheinungsbild verleiht.
+Zusätzlich ist die Oberfläche in mehrere Tabs aufgeteilt. Jeder Tab blendet die zugehörigen Abschnitte ein oder aus. Die Listen freier und aktiver Keys werden in einem Grid (`key-list`) nebeneinander dargestellt.
+
 
 Ebenfalls im Dashboard vorhanden sind Filterfelder für die Gesamtübersicht.
 Mit einer Checkbox lassen sich nur aktuell benutzte Keys anzeigen. Über ein
@@ -86,6 +88,8 @@ Und f\xc3\bcr mehrere Keys:
 Damit lassen sich mehrere Keys in einem einzigen Request \u00fcbermitteln. Die
 Antwort enth\u00e4lt unabh\u00e4ngig vom Eingabeformat stets ein Array der erzeugten
 Key-Objekte.
+ 
+Bereits vorhandene Keys werden dabei ignoriert und nicht erneut gespeichert. F\u00fchrt die Liste nur Duplikate oder ung\u00fcltige Eintr\u00e4ge, antwortet der Server mit Statuscode `400`.
 
 ### GET `/keys/free`
 Liefert den ersten verfügbaren Key (ein Key mit `inUse=false` und `invalid=false`). Gibt einen 404-Statuscode zurück, wenn keiner verfügbar ist.

--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -68,6 +68,22 @@ describe('Key Server API', () => {
     expect(stored).toHaveLength(2);
   });
 
+  test('POST /keys ignoriert bereits vorhandene Eintr\xC3\xA4ge', async () => {
+    const { app, dbPath } = await createServer();
+    const a = 'AAAAA-AAAAA-AAAAA-AAAAA-11111';
+    const b = 'BBBBB-BBBBB-BBBBB-BBBBB-22222';
+    await app.inject({ method: 'POST', url: '/keys', payload: { key: a } });
+
+    const res = await app.inject({ method: 'POST', url: '/keys', payload: { keys: [a, b] } });
+    expect(res.statusCode).toBe(201);
+    const arr = JSON.parse(res.payload);
+    expect(arr).toHaveLength(1);
+    expect(arr[0].key).toBe(b);
+
+    const stored = JSON.parse(await fs.readFile(dbPath, 'utf8'));
+    expect(stored).toHaveLength(2);
+  });
+
   test('GET /keys/free and PUT /keys/:id/inuse', async () => {
     const { app, dbPath } = await createServer();
     const k1 = 'AAAAA-AAAAA-AAAAA-AAAAA-00001';

--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -20,4 +20,12 @@ describe('Dashboard', () => {
     // Im HTML-Code muss der Verweis auf die CSS-Datei vorhanden sein
     expect(res.payload).toContain('<link rel="stylesheet" href="style.css">');
   });
+  test("enthaelt Tab-Navigation", async () => {
+    const { app } = await createServer();
+    const res = await app.inject("/");
+    expect(res.statusCode).toBe(200);
+    expect(res.payload).toContain('data-tab="overview"');
+    expect(res.payload).toContain('class="key-list"');
+  });
+
 });

--- a/public/index.html
+++ b/public/index.html
@@ -3,106 +3,122 @@
 <head>
   <meta charset="UTF-8" />
   <title>Key Server Dashboard</title>
-  <!-- Stylesheet für das Dashboard -->
+  <!-- Einbindung des Stylesheets -->
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <!-- Dashboard mit verschiedenen Abschnitten -->
   <h1>Key Server Dashboard</h1>
 
-  <section>
-  <!-- Abschnitt: Statistik -->
-    <h2>Statistik</h2>
-    <div>Freie Keys: <span id="freeCount">0</span></div>
-    <div>Benutzte Keys: <span id="usedCount">0</span></div>
-  </section>
+  <!-- Navigationsleiste für die einzelnen Tabs -->
+  <nav class="tabs">
+    <button data-tab="overview">Übersicht</button>
+    <button data-tab="actions">Aktionen</button>
+    <button data-tab="history">Historie</button>
+  </nav>
 
-  <section>
-  <!-- Abschnitt: Übersicht alle Keys -->
-    <h2>Alle Keys</h2>
-    <label><input type="checkbox" id="filterInUse" /> nur benutzte Keys</label>
-    <input type="text" id="filterAssignedTo" placeholder="Zugewiesen an" />
-    <button id="loadKeys">Laden</button>
-    <pre id="allKeys"></pre>
-  </section>
+  <!-- Tab: Statistik und Listen -->
+  <div id="overview" class="tab-content">
+    <section>
+      <h2>Statistik</h2>
+      <div>Freie Keys: <span id="freeCount">0</span></div>
+      <div>Benutzte Keys: <span id="usedCount">0</span></div>
+    </section>
 
-  <section>
-  <!-- Abschnitt: Liste freie Keys -->
-    <h2>Freie Keys</h2>
-    <pre id="listFree"></pre>
-  </section>
+    <section>
+      <h2>Freie Keys</h2>
+      <div id="listFree" class="key-list"></div>
+    </section>
 
-  <section>
-  <!-- Abschnitt: Liste aktive Keys -->
-    <h2>Aktive Keys</h2>
-    <pre id="listActive"></pre>
-  </section>
+    <section>
+      <h2>Aktive Keys</h2>
+      <div id="listActive" class="key-list"></div>
+    </section>
+  </div>
 
-  <section>
-  <!-- Abschnitt: Key hinzufügen -->
-    <h2>Neuen Key hinzufügen</h2>
-    <form id="addKeyForm">
-      <textarea id="newKey" placeholder="XXXXX-XXXXX-XXXXX-XXXXX" required></textarea>
-      <button type="submit">Hinzufügen</button>
-    </form>
-    <pre id="addKeyResult"></pre>
-  </section>
+  <!-- Tab: Aktionen für einzelne Keys -->
+  <div id="actions" class="tab-content">
+    <section>
+      <h2>Alle Keys</h2>
+      <label><input type="checkbox" id="filterInUse"> nur benutzte Keys</label>
+      <input type="text" id="filterAssignedTo" placeholder="Zugewiesen an">
+      <button id="loadKeys">Laden</button>
+      <pre id="allKeys"></pre>
+    </section>
 
-  <section>
-  <!-- Abschnitt: Freien Key abrufen -->
-    <h2>Freien Key abrufen</h2>
-    <button id="getFreeKey">Abrufen</button>
-    <pre id="freeKey"></pre>
-  </section>
+    <section>
+      <h2>Neuen Key hinzufügen</h2>
+      <form id="addKeyForm">
+        <textarea id="newKey" placeholder="XXXXX-XXXXX-XXXXX-XXXXX" required></textarea>
+        <button type="submit">Hinzufügen</button>
+      </form>
+      <pre id="addKeyResult"></pre>
+    </section>
 
-  <section>
-  <!-- Abschnitt: Key als benutzt markieren -->
-    <h2>Key als benutzt markieren</h2>
-    <form id="markInUseForm">
-      <input type="number" id="keyId" placeholder="ID" required />
-      <input type="text" id="assignedTo" placeholder="Zugewiesen an" />
-      <button type="submit">Markieren</button>
-    </form>
-    <pre id="inUseResult"></pre>
-  </section>
+    <section>
+      <h2>Freien Key abrufen</h2>
+      <button id="getFreeKey">Abrufen</button>
+      <pre id="freeKey"></pre>
+    </section>
 
-  <section>
-  <!-- Abschnitt: Key freigeben -->
-    <h2>Key freigeben</h2>
-    <form id="releaseForm">
-      <input type="number" id="releaseId" placeholder="ID" required />
-      <button type="submit">Freigeben</button>
-    </form>
-    <pre id="releaseResult"></pre>
-  </section>
+    <section>
+      <h2>Key als benutzt markieren</h2>
+      <form id="markInUseForm">
+        <input type="number" id="keyId" placeholder="ID" required>
+        <input type="text" id="assignedTo" placeholder="Zugewiesen an">
+        <button type="submit">Markieren</button>
+      </form>
+      <pre id="inUseResult"></pre>
+    </section>
 
-  <section>
-  <!-- Abschnitt: Key ungültig markieren -->
-    <h2>Key ungültig markieren</h2>
-    <form id="invalidateForm">
-      <input type="number" id="invalidateId" placeholder="ID" required />
-      <button type="submit">Key ungültig</button>
-    </form>
-    <pre id="invalidateResult"></pre>
-  </section>
+    <section>
+      <h2>Key freigeben</h2>
+      <form id="releaseForm">
+        <input type="number" id="releaseId" placeholder="ID" required>
+        <button type="submit">Freigeben</button>
+      </form>
+      <pre id="releaseResult"></pre>
+    </section>
 
-  <section>
-  <!-- Abschnitt: Key löschen -->
-    <h2>Key l\xC3\xB6schen</h2>
-    <form id="deleteForm">
-      <input type="number" id="deleteId" placeholder="ID" required />
-      <button type="submit">L\xC3\xB6schen</button>
-    </form>
-    <pre id="deleteResult"></pre>
-  </section>
+    <section>
+      <h2>Key ungültig markieren</h2>
+      <form id="invalidateForm">
+        <input type="number" id="invalidateId" placeholder="ID" required>
+        <button type="submit">Key ungültig</button>
+      </form>
+      <pre id="invalidateResult"></pre>
+    </section>
 
-  <section>
-  <!-- Abschnitt: Log anzeigen -->
-    <h2>Log</h2>
-    <pre id="historyLog"></pre>
-  </section>
+    <section>
+      <h2>Key löschen</h2>
+      <form id="deleteForm">
+        <input type="number" id="deleteId" placeholder="ID" required>
+        <button type="submit">Löschen</button>
+      </form>
+      <pre id="deleteResult"></pre>
+    </section>
+  </div>
+
+  <!-- Tab: Anzeige der Historie -->
+  <div id="history" class="tab-content">
+    <section>
+      <h2>Log</h2>
+      <pre id="historyLog"></pre>
+    </section>
+  </div>
 
   <script>
+    // Hilfsfunktion rendert eine Liste von Keys als Karten in der angegebenen Div
+    function renderList(targetId, data) {
+      const container = document.getElementById(targetId);
+      container.innerHTML = '';
+      for (const entry of data) {
+        const card = document.createElement('div');
+        card.className = 'key-card';
+        card.textContent = `${entry.id}: ${entry.key}`;
+        container.appendChild(card);
+      }
+    }
+
     async function updateStats() {
       const res = await fetch('/keys');
       const data = await res.json();
@@ -115,13 +131,13 @@
     async function loadFreeList() {
       const res = await fetch('/keys/free/list');
       const data = await res.json();
-      document.getElementById('listFree').textContent = JSON.stringify(data, null, 2);
+      renderList('listFree', data);
     }
 
     async function loadActiveList() {
       const res = await fetch('/keys/active/list');
       const data = await res.json();
-      document.getElementById('listActive').textContent = JSON.stringify(data, null, 2);
+      renderList('listActive', data);
     }
 
     async function showHistory(id) {
@@ -132,7 +148,6 @@
     }
 
     document.getElementById('loadKeys').addEventListener('click', async () => {
-      // Query-Parameter für die Filter zusammenstellen
       const params = [];
       const inUseChecked = document.getElementById('filterInUse').checked;
       if (inUseChecked) params.push('inUse=true');
@@ -150,18 +165,15 @@
 
     document.getElementById('addKeyForm').addEventListener('submit', async (e) => {
       e.preventDefault();
-      // Inhalt des Textfeldes auslesen und in einzelne Zeilen aufteilen
       const raw = document.getElementById('newKey').value;
       const keys = raw.split(/\r?\n/).map(k => k.trim()).filter(Boolean);
 
-      // Anfrage an den Server schicken, wobei ein Array von Keys übertragen wird
       const res = await fetch('/keys', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ keys })
       });
 
-      // Serverantwort anzeigen
       const data = await res.json();
       document.getElementById('addKeyResult').textContent = JSON.stringify(data, null, 2);
       updateStats();
@@ -197,7 +209,6 @@
       showHistory(id);
     });
 
-    // Setzt einen Key über die API wieder auf frei
     async function releaseKey(id) {
       const res = await fetch(`/keys/${id}/release`, { method: 'PUT' });
       const data = await res.json();
@@ -215,7 +226,6 @@
       await releaseKey(id);
     });
 
-    // Markiert einen Key als ungültig
     async function invalidateKey(id) {
       const res = await fetch(`/keys/${id}/invalidate`, { method: 'PUT' });
       const data = await res.json();
@@ -233,7 +243,6 @@
       await invalidateKey(id);
     });
 
-    // L\xC3\xB6scht einen Key permanent vom Server
     async function deleteKey(id) {
       const res = await fetch(`/keys/${id}`, { method: 'DELETE' });
       const data = await res.json();
@@ -241,7 +250,6 @@
       updateStats();
       loadFreeList();
       loadActiveList();
-      // Nach dem L\xC3\xB6schen ist keine Historie mehr vorhanden
       document.getElementById('historyLog').textContent = '';
       return data;
     }
@@ -252,7 +260,19 @@
       await deleteKey(id);
     });
 
+    // Tab-Umschaltung für die Navigation
+    document.querySelectorAll('nav.tabs button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const tab = btn.getAttribute('data-tab');
+        document.querySelectorAll('.tab-content').forEach(c => {
+          c.style.display = 'none';
+        });
+        document.getElementById(tab).style.display = 'block';
+      });
+    });
+
     document.addEventListener('DOMContentLoaded', () => {
+      document.querySelector('nav.tabs button').click();
       updateStats();
       loadFreeList();
       loadActiveList();

--- a/public/style.css
+++ b/public/style.css
@@ -1,21 +1,48 @@
 /*
- * Dieses Stylesheet verleiht dem Dashboard ein modernes Erscheinungsbild.
- * Hier werden grundlegende Layout- und Farbregeln definiert.
+ * Modernes Dashboard-Layout mit CSS-Variablen und Grid
  */
+
+:root {
+  --bg-color: #fdfdfd;
+  --text-color: #333;
+  --border-color: #ddd;
+  --primary: #007bff;
+  --primary-hover: #0056b3;
+}
 
 body {
   font-family: sans-serif;
-  max-width: 800px;
+  max-width: 900px;
   margin: auto;
-  background: #fdfdfd;
-  color: #333;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
+nav.tabs {
+  margin-bottom: 1em;
+  display: flex;
+  gap: 0.5em;
+}
+
+nav.tabs button {
+  padding: 0.5em 1em;
+  border: 1px solid var(--border-color);
+  background: var(--primary);
+  color: #fff;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+nav.tabs button:hover {
+  background: var(--primary-hover);
 }
 
 section {
   margin-bottom: 1.5em;
   padding: 1em;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
+  background: #fff;
 }
 
 form {
@@ -32,7 +59,7 @@ form textarea {
 }
 
 button {
-  background-color: #007bff;
+  background-color: var(--primary);
   color: #fff;
   border: none;
   padding: 0.5em 1em;
@@ -41,5 +68,18 @@ button {
 }
 
 button:hover {
-  background-color: #0056b3;
+  background-color: var(--primary-hover);
+}
+
+.key-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.5em;
+}
+
+.key-card {
+  border: 1px solid var(--border-color);
+  padding: 0.5em;
+  border-radius: 4px;
+  background: #fff;
 }

--- a/server.js
+++ b/server.js
@@ -81,6 +81,8 @@ async function buildServer(options = {}) {
     for (const entry of incoming) {
       // Ungültige Keys überspringen
       if (!pattern.test(entry)) continue;
+      // Bereits vorhandene Keys nicht erneut anlegen
+      if (keys.some((k) => k.key === entry)) continue;
 
       const now = new Date().toISOString();
       const newKey = {


### PR DESCRIPTION
## Summary
- restructure dashboard with tabs and CSS grid
- update styles to use CSS variables
- implement tab switching in JS
- document new layout in README
- extend tests for new tab navigation
- skip duplicate keys on insert

## Testing
- `npm test` *(fails: jest not found)*