### PR TITLE
Verbessertes Dashboard mit Key-Aktionen

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,12 @@ Ein einfacher Fastify-Server, der Windows-Keys in einer In-Memory-Liste verwalte
 ## Dashboard
 
 Nach dem Start kann [http://localhost:3000/](http://localhost:3000/) im Browser
-aufgerufen werden, um eine einfache HTML-Oberfläche für die REST-Endpunkte zu
-nutzen. Dort werden nun zusätzlich Listen aller freien und aller aktuell
-benutzten Keys angezeigt. Diese Daten stammen aus den Endpunkten
-`/keys/free/list` und `/keys/active/list`.
-Das Layout verwendet nun eine eigene CSS-Datei `public/style.css`, die dem Dashboard ein moderneres Erscheinungsbild verleiht.
-Zusätzlich ist die Oberfläche in mehrere Tabs aufgeteilt. Jeder Tab blendet die zugehörigen Abschnitte ein oder aus. Die Listen freier und aktiver Keys werden in einem Grid (`key-list`) nebeneinander dargestellt.
+aufgerufen werden, um eine einfache HTML-Oberfläche für die REST-Endpunkte zu nutzen. Dort werden Listen aller freien und aller aktuell benutzten Keys angezeigt. Diese Daten stammen aus den Endpunkten `/keys/free/list` und `/keys/active/list`.
+Das Layout verwendet eine eigene CSS-Datei `public/style.css`, die dem Dashboard ein modernes Erscheinungsbild verleiht.
+Die Oberfläche ist in mehrere Tabs aufgeteilt. Jeder Tab blendet die zugehörigen Abschnitte ein oder aus. Die Listen der Keys sind nun als vertikale Liste umgesetzt.
+Zu jedem Eintrag stehen Schaltflächen bereit, um den Key zu kopieren, zu löschen, freizugeben, als benutzt oder ungültig zu markieren sowie die Historie einzusehen.
 
-
+Zusätzlich gibt es nun in der Statistik einen Zähler für ungültige Keys.
 Ebenfalls im Dashboard vorhanden sind Filterfelder für die Gesamtübersicht.
 Mit einer Checkbox lassen sich nur aktuell benutzte Keys anzeigen. Über ein
 Textfeld kann zudem nach dem Wert des Feldes `assignedTo` gefiltert werden.

--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -26,6 +26,8 @@ describe('Dashboard', () => {
     expect(res.statusCode).toBe(200);
     expect(res.payload).toContain('data-tab="overview"');
     expect(res.payload).toContain('class="key-list"');
+    expect(res.payload).toContain('Aktivierte Keys');
+    expect(res.payload).toContain('invalidCount');
   });
 
 });

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
       <h2>Statistik</h2>
       <div>Freie Keys: <span id="freeCount">0</span></div>
       <div>Benutzte Keys: <span id="usedCount">0</span></div>
+      <div>Ungültige Keys: <span id="invalidCount">0</span></div>
     </section>
 
     <section>
@@ -30,7 +31,7 @@
     </section>
 
     <section>
-      <h2>Aktive Keys</h2>
+      <h2>Aktivierte Keys</h2>
       <div id="listActive" class="key-list"></div>
     </section>
   </div>
@@ -107,15 +108,74 @@
   </div>
 
   <script>
-    // Hilfsfunktion rendert eine Liste von Keys als Karten in der angegebenen Div
+    // Erstellt einen Button für die Key-Aktionen
+    function createActionButton(text, handler) {
+      const btn = document.createElement('button');
+      btn.textContent = text;
+      btn.addEventListener('click', handler);
+      return btn;
+    }
+
+    // Markiert einen Key als benutzt
+    async function markKeyInUse(id, assignedTo = '') {
+      const res = await fetch(`/keys/${id}/inuse`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ assignedTo })
+      });
+      const data = await res.json();
+      document.getElementById('inUseResult').textContent = JSON.stringify(data, null, 2);
+      updateStats();
+      loadFreeList();
+      loadActiveList();
+      showHistory(id);
+      return data;
+    }
+
+    // Rendert die Keys mit zugehörigen Aktionsknöpfen untereinander
     function renderList(targetId, data) {
       const container = document.getElementById(targetId);
       container.innerHTML = '';
+      data.sort((a, b) => a.id - b.id);
       for (const entry of data) {
-        const card = document.createElement('div');
-        card.className = 'key-card';
-        card.textContent = `${entry.id}: ${entry.key}`;
-        container.appendChild(card);
+        const row = document.createElement('div');
+        row.className = 'key-row';
+
+        const text = document.createElement('span');
+        text.textContent = `${entry.id}: ${entry.key}`;
+        row.appendChild(text);
+
+        const actions = document.createElement('div');
+        actions.className = 'key-actions';
+
+        actions.appendChild(createActionButton('Benutzen', () => {
+          const assigned = prompt('Zugewiesen an?') || '';
+          markKeyInUse(entry.id, assigned);
+        }));
+
+        actions.appendChild(createActionButton('Freigeben', () => {
+          releaseKey(entry.id);
+        }));
+
+        actions.appendChild(createActionButton('Ungültig', () => {
+          invalidateKey(entry.id);
+        }));
+
+        actions.appendChild(createActionButton('Löschen', () => {
+          deleteKey(entry.id);
+        }));
+
+        actions.appendChild(createActionButton('Kopieren', () => {
+          navigator.clipboard.writeText(entry.key).catch(() => {});
+        }));
+
+        actions.appendChild(createActionButton('Historie', () => {
+          showHistory(entry.id);
+          document.querySelector('nav.tabs button[data-tab="history"]').click();
+        }));
+
+        row.appendChild(actions);
+        container.appendChild(row);
       }
     }
 
@@ -124,8 +184,10 @@
       const data = await res.json();
       const free = data.filter(k => !k.inUse).length;
       const used = data.filter(k => k.inUse).length;
+      const invalid = data.filter(k => k.invalid).length;
       document.getElementById('freeCount').textContent = free;
       document.getElementById('usedCount').textContent = used;
+      document.getElementById('invalidCount').textContent = invalid;
     }
 
     async function loadFreeList() {
@@ -196,17 +258,7 @@
       e.preventDefault();
       const id = document.getElementById('keyId').value;
       const assignedTo = document.getElementById('assignedTo').value;
-      const res = await fetch(`/keys/${id}/inuse`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ assignedTo })
-      });
-      const data = await res.json();
-      document.getElementById('inUseResult').textContent = JSON.stringify(data, null, 2);
-      updateStats();
-      loadFreeList();
-      loadActiveList();
-      showHistory(id);
+      await markKeyInUse(id, assignedTo);
     });
 
     async function releaseKey(id) {

--- a/public/style.css
+++ b/public/style.css
@@ -72,14 +72,22 @@ button:hover {
 }
 
 .key-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 0.5em;
 }
 
-.key-card {
+.key-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   border: 1px solid var(--border-color);
   padding: 0.5em;
   border-radius: 4px;
   background: #fff;
+}
+
+.key-actions {
+  display: flex;
+  gap: 0.5em;
 }


### PR DESCRIPTION
## Summary
- keys werden nun im Dashboard in einer Liste angezeigt
- pro Eintrag gibt es Buttons für Benutzen, Freigeben, Ungültig, Löschen, Kopieren und Historie
- Statistik zeigt zusätzlich die Anzahl ungültiger Keys
- Tab "Aktive Keys" heißt nun "Aktivierte Keys"
- CSS für neue Listenansicht und Aktionen
- Dokumentation angepasst
- Tests für das Dashboard erweitert

## Testing
- `npm test`