### PR TITLE
Improve theme toggle and icon buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Das Layout verwendet eine eigene CSS-Datei `public/style.css`, die dem Dashboard
 Die Oberfläche ist in mehrere Tabs aufgeteilt. Jeder Tab blendet die zugehörigen Abschnitte ein oder aus. Die Listen der Keys sind nun als vertikale Liste umgesetzt.
 Zu jedem Eintrag stehen Schaltflächen bereit, um den Key zu kopieren, zu löschen, freizugeben, als benutzt oder ungültig zu markieren sowie die Historie einzusehen.
 
+Neu ist ein Button oben rechts, der zwischen hellem und dunklem Design umschaltet. Die Auswahl wird im Browser gespeichert, sodass das bevorzugte Design bei einem erneuten Besuch direkt aktiv ist. Die Farben werden weiterhin über CSS-Variablen angepasst.
+Die Aktionsknöpfe in den Key-Listen werden nun als farbige Symbole dargestellt, was die Bedienung vereinfacht.
+Antworten des Servers erscheinen in kleinen Ergebnisboxen direkt unter den Formularen. Beim Abrufen eines freien Keys wird zusätzlich ein Kopieren-Button angeboten.
+
 Zusätzlich gibt es nun in der Statistik einen Zähler für ungültige Keys.
 Ebenfalls im Dashboard vorhanden sind Filterfelder für die Gesamtübersicht.
 Mit einer Checkbox lassen sich nur aktuell benutzte Keys anzeigen. Über ein

--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -30,4 +30,22 @@ describe('Dashboard', () => {
     expect(res.payload).toContain('invalidCount');
   });
 
+  test('enthält Darkmode-Button', async () => {
+    const { app } = await createServer();
+    const res = await app.inject('/');
+    expect(res.payload).toContain('id="themeToggle"');
+  });
+
+  test('verwendet Ergebnisboxen', async () => {
+    const { app } = await createServer();
+    const res = await app.inject('/');
+    expect(res.payload).toContain('class="result-box"');
+  });
+
+  test('nutzt Icon-Buttons', async () => {
+    const { app } = await createServer();
+    const res = await app.inject('/');
+    expect(res.payload).toContain('icon-button');
+  });
+
 });

--- a/public/index.html
+++ b/public/index.html
@@ -10,12 +10,16 @@
   <header class="container">
     <h1>Key Server Dashboard</h1>
 
-    <!-- Navigationsleiste für die einzelnen Tabs -->
-    <nav class="tabs">
-      <button data-tab="overview">Übersicht</button>
-      <button data-tab="actions">Aktionen</button>
-      <button data-tab="history">Historie</button>
-    </nav>
+    <div class="toolbar">
+      <!-- Navigationsleiste für die einzelnen Tabs -->
+      <nav class="tabs">
+        <button data-tab="overview">Übersicht</button>
+        <button data-tab="actions">Aktionen</button>
+        <button data-tab="history">Historie</button>
+      </nav>
+      <!-- Schalter für Dark-/Lightmode -->
+      <button id="themeToggle" aria-label="Design wechseln">🌙</button>
+    </div>
   </header>
 
   <main class="container">
@@ -47,7 +51,7 @@
       <label><input type="checkbox" id="filterInUse"> nur benutzte Keys</label>
       <input type="text" id="filterAssignedTo" placeholder="Zugewiesen an">
       <button id="loadKeys">Laden</button>
-      <pre id="allKeys"></pre>
+      <div id="allKeys" class="result-box"></div>
     </section>
 
     <section>
@@ -56,13 +60,13 @@
         <textarea id="newKey" placeholder="XXXXX-XXXXX-XXXXX-XXXXX" required></textarea>
         <button type="submit">Hinzufügen</button>
       </form>
-      <pre id="addKeyResult"></pre>
+      <div id="addKeyResult" class="result-box"></div>
     </section>
 
     <section>
       <h2>Freien Key abrufen</h2>
       <button id="getFreeKey">Abrufen</button>
-      <pre id="freeKey"></pre>
+      <div id="freeKey" class="result-box"></div>
     </section>
 
     <section>
@@ -72,7 +76,7 @@
         <input type="text" id="assignedTo" placeholder="Zugewiesen an">
         <button type="submit">Markieren</button>
       </form>
-      <pre id="inUseResult"></pre>
+      <div id="inUseResult" class="result-box"></div>
     </section>
 
     <section>
@@ -81,7 +85,7 @@
         <input type="number" id="releaseId" placeholder="ID" required>
         <button type="submit">Freigeben</button>
       </form>
-      <pre id="releaseResult"></pre>
+      <div id="releaseResult" class="result-box"></div>
     </section>
 
     <section>
@@ -90,7 +94,7 @@
         <input type="number" id="invalidateId" placeholder="ID" required>
         <button type="submit">Key ungültig</button>
       </form>
-      <pre id="invalidateResult"></pre>
+      <div id="invalidateResult" class="result-box"></div>
     </section>
 
     <section>
@@ -99,7 +103,7 @@
         <input type="number" id="deleteId" placeholder="ID" required>
         <button type="submit">Löschen</button>
       </form>
-      <pre id="deleteResult"></pre>
+      <div id="deleteResult" class="result-box"></div>
     </section>
   </div>
 
@@ -107,19 +111,73 @@
   <div id="history" class="tab-content">
     <section>
       <h2>Log</h2>
-      <pre id="historyLog"></pre>
+      <div id="historyLog" class="result-box" style="white-space: pre-wrap;"></div>
     </section>
   </div>
 
   </main>
 
   <script>
-    // Erstellt einen Button für die Key-Aktionen
-    function createActionButton(text, handler) {
+    /*
+     * Schaltet zwischen hellem und dunklem Design um. Die Auswahl
+     * wird in localStorage gesichert und beim Laden wiederhergestellt.
+     */
+    const themeToggle = document.getElementById('themeToggle');
+
+    function applyTheme(mode) {
+      document.body.classList.remove('light', 'dark');
+      if (mode) document.body.classList.add(mode);
+    }
+
+    themeToggle.addEventListener('click', () => {
+      const current = document.body.classList.contains('dark') ? 'dark'
+        : document.body.classList.contains('light') ? 'light' : null;
+      const next = current === 'dark' ? 'light' : 'dark';
+      applyTheme(next);
+      try { localStorage.setItem('theme', next); } catch (e) {}
+    });
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const saved = localStorage.getItem('theme');
+      if (saved) applyTheme(saved);
+    });
+
+    // Erstellt einen Symbol-Button für die Key-Aktionen
+    function createIconButton(icon, title, className, handler) {
       const btn = document.createElement('button');
-      btn.textContent = text;
+      btn.className = 'icon-button ' + className;
+      btn.textContent = icon;
+      btn.title = title;
       btn.addEventListener('click', handler);
       return btn;
+    }
+
+    // Zeigt ein JSON-Objekt übersichtlich in einer Ergebnisbox an
+    function displayJson(id, obj) {
+      const box = document.getElementById(id);
+      box.innerHTML = '';
+      const pre = document.createElement('pre');
+      pre.textContent = JSON.stringify(obj, null, 2);
+      box.appendChild(pre);
+    }
+
+    // Stellt einen einzelnen Key mit Copy-Button dar
+    function showFreeKey(data) {
+      const box = document.getElementById('freeKey');
+      box.innerHTML = '';
+      if (!data || !data.key) return;
+
+      const span = document.createElement('span');
+      span.textContent = data.key;
+
+      const copy = document.createElement('button');
+      copy.textContent = 'Kopieren';
+      copy.addEventListener('click', () => {
+        navigator.clipboard.writeText(data.key).catch(() => {});
+      });
+
+      box.appendChild(span);
+      box.appendChild(copy);
     }
 
     // Markiert einen Key als benutzt
@@ -130,7 +188,7 @@
         body: JSON.stringify({ assignedTo })
       });
       const data = await res.json();
-      document.getElementById('inUseResult').textContent = JSON.stringify(data, null, 2);
+      displayJson('inUseResult', data);
       updateStats();
       loadFreeList();
       loadActiveList();
@@ -154,28 +212,28 @@
         const actions = document.createElement('div');
         actions.className = 'key-actions';
 
-        actions.appendChild(createActionButton('Benutzen', () => {
+        actions.appendChild(createIconButton('✔️', 'Benutzen', 'icon-button icon-use', () => {
           const assigned = prompt('Zugewiesen an?') || '';
           markKeyInUse(entry.id, assigned);
         }));
 
-        actions.appendChild(createActionButton('Freigeben', () => {
+        actions.appendChild(createIconButton('↩️', 'Freigeben', 'icon-button icon-release', () => {
           releaseKey(entry.id);
         }));
 
-        actions.appendChild(createActionButton('Ungültig', () => {
+        actions.appendChild(createIconButton('🚫', 'Ungültig', 'icon-button icon-invalidate', () => {
           invalidateKey(entry.id);
         }));
 
-        actions.appendChild(createActionButton('Löschen', () => {
+        actions.appendChild(createIconButton('🗑️', 'Löschen', 'icon-button icon-delete', () => {
           deleteKey(entry.id);
         }));
 
-        actions.appendChild(createActionButton('Kopieren', () => {
+        actions.appendChild(createIconButton('📋', 'Kopieren', 'icon-button icon-copy', () => {
           navigator.clipboard.writeText(entry.key).catch(() => {});
         }));
 
-        actions.appendChild(createActionButton('Historie', () => {
+        actions.appendChild(createIconButton('📜', 'Historie', 'icon-button icon-history', () => {
           showHistory(entry.id);
           document.querySelector('nav.tabs button[data-tab="history"]').click();
         }));
@@ -212,7 +270,7 @@
       if (!id) return;
       const res = await fetch(`/keys/${id}/history`);
       const hist = await res.json();
-      document.getElementById('historyLog').textContent = JSON.stringify(hist, null, 2);
+      displayJson('historyLog', hist);
     }
 
     document.getElementById('loadKeys').addEventListener('click', async () => {
@@ -225,7 +283,7 @@
 
       const res = await fetch('/keys' + query);
       const data = await res.json();
-      document.getElementById('allKeys').textContent = JSON.stringify(data, null, 2);
+      displayJson('allKeys', data);
       updateStats();
       loadFreeList();
       loadActiveList();
@@ -243,7 +301,7 @@
       });
 
       const data = await res.json();
-      document.getElementById('addKeyResult').textContent = JSON.stringify(data, null, 2);
+      displayJson('addKeyResult', data);
       updateStats();
       loadFreeList();
       loadActiveList();
@@ -253,7 +311,7 @@
     document.getElementById('getFreeKey').addEventListener('click', async () => {
       const res = await fetch('/keys/free');
       const data = await res.json();
-      document.getElementById('freeKey').textContent = JSON.stringify(data, null, 2);
+      showFreeKey(data);
       updateStats();
       loadFreeList();
       loadActiveList();
@@ -270,7 +328,7 @@
     async function releaseKey(id) {
       const res = await fetch(`/keys/${id}/release`, { method: 'PUT' });
       const data = await res.json();
-      document.getElementById('releaseResult').textContent = JSON.stringify(data, null, 2);
+      displayJson('releaseResult', data);
       updateStats();
       loadFreeList();
       loadActiveList();
@@ -287,7 +345,7 @@
     async function invalidateKey(id) {
       const res = await fetch(`/keys/${id}/invalidate`, { method: 'PUT' });
       const data = await res.json();
-      document.getElementById('invalidateResult').textContent = JSON.stringify(data, null, 2);
+      displayJson('invalidateResult', data);
       updateStats();
       loadFreeList();
       loadActiveList();
@@ -304,7 +362,7 @@
     async function deleteKey(id) {
       const res = await fetch(`/keys/${id}`, { method: 'DELETE' });
       const data = await res.json();
-      document.getElementById('deleteResult').textContent = JSON.stringify(data, null, 2);
+      displayJson('deleteResult', data);
       updateStats();
       loadFreeList();
       loadActiveList();

--- a/public/style.css
+++ b/public/style.css
@@ -28,6 +28,30 @@
   }
 }
 
+/*
+ * Wird die Klasse "dark" auf <body> gesetzt, überschreiben diese
+ * Werte die Farbvariablen und erzwingen damit den Darkmode.
+ */
+body.dark {
+  --bg-color: #1d1d1d;
+  --text-color: #eee;
+  --border-color: #444;
+  --card-bg: #2a2a2a;
+  --primary: #0a84ff;
+  --primary-hover: #006edc;
+}
+
+/* Wird die Klasse "light" gesetzt, wird der helle Stil auch bei
+ * systemweitem Darkmode erzwungen. */
+body.light {
+  --bg-color: #fdfdfd;
+  --text-color: #333;
+  --border-color: #ddd;
+  --card-bg: #fff;
+  --primary: #007bff;
+  --primary-hover: #0056b3;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: var(--bg-color);
@@ -44,6 +68,30 @@ body {
   margin: 0 auto;
   padding: 1rem;
   flex: 1;
+}
+
+header.container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+#themeToggle {
+  font-size: 1.2rem;
+  background: none;
+  border: 1px solid var(--border-color);
+  padding: 0.25em 0.5em;
+  border-radius: 4px;
+}
+
+#themeToggle:hover {
+  background: var(--card-bg);
 }
 
 nav.tabs {
@@ -96,6 +144,20 @@ button {
   cursor: pointer;
 }
 
+/* Buttons, die nur ein Symbol enthalten und farblich hervorgehoben werden */
+.icon-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+.icon-use { color: green; }
+.icon-release { color: orange; }
+.icon-invalidate { color: gray; }
+.icon-delete { color: red; }
+.icon-copy { color: var(--primary); }
+.icon-history { color: var(--text-color); }
+
 button:hover {
   background-color: var(--primary-hover);
 }
@@ -119,4 +181,21 @@ button:hover {
 .key-actions {
   display: flex;
   gap: 0.5em;
+}
+
+/* Box zur Darstellung von Serverantworten, z.B. ein abgerufener Key */
+.result-box {
+  margin-top: 0.5em;
+  padding: 0.75em;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--card-bg);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: monospace;
+}
+.result-box pre {
+  margin: 0;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
## Summary
- persist dark/light mode and restore on reload
- create icon buttons for key actions
- display JSON responses with `<pre>` for better readability
- document theme persistence and new icons in README
- test for presence of icon buttons

## Testing
- `npm test`