### PR TITLE
Add hover titles to action buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Zu jedem Eintrag stehen Schaltflächen bereit, um den Key zu kopieren, zu lösch
 
 Neu ist ein Button oben rechts, der zwischen hellem und dunklem Design umschaltet. Die Auswahl wird im Browser gespeichert, sodass das bevorzugte Design bei einem erneuten Besuch direkt aktiv ist. Die Farben werden weiterhin über CSS-Variablen angepasst.
 Die Aktionsknöpfe in den Key-Listen werden nun als farbige Symbole dargestellt, was die Bedienung vereinfacht.
+Beim Überfahren der Symbole erscheint ein kurzer Hinweis, der die jeweilige Aktion beschreibt.
 
 Antworten des Servers erscheinen in kleinen Ergebnisboxen direkt unter den Formularen. Beim Abrufen eines freien Keys wird zusätzlich ein Kopieren-Button angeboten.
 

--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -49,5 +49,15 @@ describe('Dashboard', () => {
     expect(res.payload).toContain('icon-button');
   });
 
+  test('createActionButton setzt optionalen Titel', async () => {
+    const { app } = await createServer();
+    const res = await app.inject('/');
+    const { JSDOM } = require('../test-utils/fake-dom');
+    const dom = new JSDOM(res.payload, { runScripts: 'dangerously' });
+    const btn = dom.window.createActionButton('x', 'icon-test', () => {}, 'Titel');
+    expect(btn.getAttribute('title')).toBe('Titel');
+    expect(btn.getAttribute('aria-label')).toBe('Titel');
+  });
+
 
 });

--- a/public/index.html
+++ b/public/index.html
@@ -144,12 +144,16 @@
     });
 
     // Erstellt einen Symbol-Button für die Key-Aktionen
-    function createIconButton(icon, title, className, handler) {
+    // title ist optional und liefert einen Tooltip sowie ein ARIA-Label
+    function createActionButton(icon, className, handler, title) {
 
       const btn = document.createElement('button');
       btn.className = 'icon-button ' + className;
       btn.textContent = icon;
-      btn.title = title;
+      if (title) {
+        btn.title = title;
+        btn.setAttribute('aria-label', title);
+      }
       btn.addEventListener('click', handler);
       return btn;
     }
@@ -216,31 +220,31 @@
         const actions = document.createElement('div');
         actions.className = 'key-actions';
 
-        actions.appendChild(createIconButton('✔️', 'Benutzen', 'icon-button icon-use', () => {
+        actions.appendChild(createActionButton('✔️', 'icon-use', () => {
           const assigned = prompt('Zugewiesen an?') || '';
           markKeyInUse(entry.id, assigned);
-        }));
+        }, 'Benutzen'));
 
-        actions.appendChild(createIconButton('↩️', 'Freigeben', 'icon-button icon-release', () => {
+        actions.appendChild(createActionButton('↩️', 'icon-release', () => {
           releaseKey(entry.id);
-        }));
+        }, 'Freigeben'));
 
-        actions.appendChild(createIconButton('🚫', 'Ungültig', 'icon-button icon-invalidate', () => {
+        actions.appendChild(createActionButton('🚫', 'icon-invalidate', () => {
           invalidateKey(entry.id);
-        }));
+        }, 'Ungültig'));
 
-        actions.appendChild(createIconButton('🗑️', 'Löschen', 'icon-button icon-delete', () => {
+        actions.appendChild(createActionButton('🗑️', 'icon-delete', () => {
           deleteKey(entry.id);
-        }));
+        }, 'Löschen'));
 
-        actions.appendChild(createIconButton('📋', 'Kopieren', 'icon-button icon-copy', () => {
+        actions.appendChild(createActionButton('📋', 'icon-copy', () => {
           navigator.clipboard.writeText(entry.key).catch(() => {});
-        }));
+        }, 'Kopieren'));
 
-        actions.appendChild(createIconButton('📜', 'Historie', 'icon-button icon-history', () => {
+        actions.appendChild(createActionButton('📜', 'icon-history', () => {
           showHistory(entry.id);
           document.querySelector('nav.tabs button[data-tab="history"]').click();
-        }));
+        }, 'Historie'));
 
         row.appendChild(actions);
         container.appendChild(row);

--- a/test-utils/fake-dom.js
+++ b/test-utils/fake-dom.js
@@ -1,0 +1,34 @@
+const vm = require('vm');
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag.toUpperCase();
+    this.attributes = {};
+    this.textContent = '';
+    this.className = '';
+    this.title = '';
+  }
+  setAttribute(name, value) { this.attributes[name] = value; }
+  getAttribute(name) { return this.attributes[name] ?? this[name]; }
+  appendChild() {}
+  addEventListener() {}
+}
+
+class Document {
+  createElement(tag) { return new Element(tag); }
+}
+
+class JSDOM {
+  constructor(html, options = {}) {
+    this.window = { document: new Document() };
+    if (options.runScripts === 'dangerously') {
+      const match = html.match(/<script[^>]*>([\s\S]*?)<\/script>/);
+      if (match) {
+        const funcMatch = match[1].match(/function createActionButton[\s\S]*?return btn;\s*}/);
+        if (funcMatch) vm.runInNewContext(funcMatch[0], this.window);
+      }
+    }
+  }
+}
+
+module.exports = { JSDOM };


### PR DESCRIPTION
## Summary
- enhance action button creation to support titles and aria labels
- use new titles for all action buttons
- test action button helper using a lightweight DOM emulation
- mention new tooltips in README

## Testing
- `npm test`