### PR TITLE
Add file logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ eines freien Keys, das Markieren als benutzt, das Freigeben sowie das Löschen
 eines Eintrags. Die Log-Ausgaben erscheinen auf der Konsole und können zur
 Nachverfolgung der Vorgänge genutzt werden.
 
+Soll zusätzlich eine Logdatei geführt werden, kann beim Start ein Pfad
+übergeben werden. Dieser wird als erstes Argument an `index.js` gereicht und
+unter dem Optionsnamen `logFile` verwendet. Beispiel:
+
+```bash
+npm start -- ./server.log
+```
+
+Damit schreibt Pino alle Logeinträge in die angegebene Datei.
+
 ## Tests
 
 Um sicherzustellen, dass alle Funktionen weiterhin korrekt arbeiten, existieren Jest-Tests im Verzeichnis `__tests__`. Diese decken sämtliche REST-Endpunkte sowie das Dashboard ab. Die Ausführung inklusive Testabdeckung erfolgt mit:

--- a/__tests__/logging.test.js
+++ b/__tests__/logging.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs/promises');
+const path = require('path');
+const os = require('os');
+const buildServer = require('../server');
+
+// Dieser Test prüft, ob Logeinträge tatsächlich in einer angegebenen Datei landen
+
+describe('Logging in Datei', () => {
+  test('schreibt Einträge in angegebene Logdatei', async () => {
+    const dbPath = path.join(os.tmpdir(), `db-${Date.now()}-${Math.random()}.json`);
+    const logPath = path.join(os.tmpdir(), `log-${Date.now()}-${Math.random()}.log`);
+    await fs.writeFile(dbPath, '[]');
+
+    const app = await buildServer({ logger: true, dbFile: dbPath, logFile: logPath });
+
+    // Ein Key wird angelegt und anschließend abgefragt, um Logeinträge zu erzeugen
+    await app.inject({ method: 'POST', url: '/keys', payload: { key: 'AAAAA-BBBBB-CCCCC-DDDDD-EEEEE' } });
+    await app.inject('/keys/free');
+
+    // Kurze Wartezeit, damit Pino die Daten schreibt
+    await new Promise((r) => setTimeout(r, 10));
+
+    const content = await fs.readFile(logPath, 'utf8');
+    expect(content).toMatch(/Freier Key ausgegeben/);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ const buildServer = require('./server');
 // beendet den Prozess bei unerwarteten Fehlern.
 const start = async () => {
   try {
-    const app = await buildServer({ logger: true });
+    // Optionaler Pfad für eine Logdatei wird als erstes Argument erwartet
+    const logFile = process.argv[2];
+    const app = await buildServer({ logger: true, logFile });
     await app.listen({ port: 3000, host: '0.0.0.0' });
     console.log('Server läuft auf Port 3000');
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "fastify": "^4.22.2",
-    "@fastify/static": "^7.0.0"
+    "@fastify/static": "^7.0.0",
+    "pino": "^8.17.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server.js
+++ b/server.js
@@ -1,14 +1,19 @@
 const fastify = require('fastify');
 const fs = require('fs/promises');
 const path = require('path');
+// Pino wird verwendet, um wahlweise in eine Logdatei zu schreiben
+const pino = require('pino');
 
 async function buildServer(options = {}) {
   const {
     logger = false,
     dbFile = path.join(__dirname, 'db.json'),
+    logFile,
   } = options;
 
-  const app = fastify({ logger });
+  // Wird ein Dateipfad angegeben, schreibt der Logger dahin
+  const destination = logFile ? pino.destination(logFile) : undefined;
+  const app = fastify({ logger: destination ? { stream: destination } : logger });
 
   app.register(require('@fastify/static'), {
     root: path.join(__dirname, 'public'),


### PR DESCRIPTION
## Summary
- allow optional logfile parameter in `index.js`
- configure Fastify logger to write to file in `server.js`
- document logfile usage in README
- add jest test verifying logfile output
- add `pino` as dependency

## Testing
- `npm test`