### PR TITLE
Add Telegram low-key notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,20 @@ npm start -- ./server.log
 
 Damit schreibt Pino alle Logeinträge in die angegebene Datei.
 
+## Telegram-Benachrichtigung
+
+Ist ein Bot-Token sowie eine Chat-ID hinterlegt, informiert der Server per
+Telegram, sobald weniger als 20 freie Keys vorhanden sind. Dazu müssen folgende
+Variablen gesetzt werden:
+
+```bash
+export TELEGRAM_BOT_TOKEN="<TOKEN>"
+export TELEGRAM_CHAT_ID="<CHAT_ID>"
+```
+
+Sinkt der Bestand unter die genannte Schwelle, verschickt der Server automatisch
+eine Warnung an das angegebene Konto.
+
 ## Tests
 
 Um sicherzustellen, dass alle Funktionen weiterhin korrekt arbeiten, existieren Jest-Tests im Verzeichnis `__tests__`. Diese decken sämtliche REST-Endpunkte sowie das Dashboard ab. Die Ausführung inklusive Testabdeckung erfolgt mit:

--- a/__tests__/telegram.test.js
+++ b/__tests__/telegram.test.js
@@ -1,0 +1,60 @@
+const fs = require('fs/promises');
+const path = require('path');
+const os = require('os');
+
+jest.mock('../telegram', () => ({
+  sendTelegramMessage: jest.fn()
+}));
+
+const { sendTelegramMessage } = require('../telegram');
+const buildServer = require('../server');
+
+async function createServerWithKeys(count) {
+  const dbPath = path.join(os.tmpdir(), `db-${Date.now()}-${Math.random()}.json`);
+  const keys = [];
+  for (let i = 0; i < count; i++) {
+    keys.push({
+      id: i + 1,
+      key: `AAAAA-BBBBB-CCCCC-DDDDD-${String(i).padStart(5, '0')}`,
+      inUse: false,
+      assignedTo: null,
+      createdAt: new Date().toISOString(),
+      lastUsedAt: null,
+      history: [],
+      invalid: false
+    });
+  }
+  await fs.writeFile(dbPath, JSON.stringify(keys));
+  const app = await buildServer({ logger: false, dbFile: dbPath });
+  return { app, dbPath };
+}
+
+describe('Telegram Integration', () => {
+  beforeEach(() => {
+    sendTelegramMessage.mockClear();
+  });
+
+  test('sendTelegramMessage ruft Telegram API auf', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ json: async () => ({ ok: true }) });
+    await sendTelegramMessage('TOKEN', '1', 'Hallo');
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.telegram.org/botTOKEN/sendMessage',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: '1', text: 'Hallo' })
+      })
+    );
+  });
+
+  test('Server benachrichtigt bei wenig freien Keys', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'T';
+    process.env.TELEGRAM_CHAT_ID = 'C';
+    const { app } = await createServerWithKeys(19);
+    await app.inject({ method: 'PUT', url: '/keys/1/inuse', payload: {} });
+    expect(sendTelegramMessage).toHaveBeenCalledTimes(1);
+    await app.close();
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.TELEGRAM_CHAT_ID;
+  });
+});

--- a/telegram.js
+++ b/telegram.js
@@ -1,0 +1,21 @@
+const fetch = global.fetch;
+
+/**
+ * Sendet eine Nachricht über die Telegram Bot API.
+ * @param {string} token  Bot-Token aus BotFather
+ * @param {string|number} chatId  ID des Chats oder Nutzers
+ * @param {string} text  Zu sendender Nachrichtentext
+ * @returns {Promise<any>} Antwort der Telegram API
+ */
+async function sendTelegramMessage(token, chatId, text) {
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId, text }),
+  });
+  return res.json();
+}
+
+module.exports = { sendTelegramMessage };
+


### PR DESCRIPTION
## Summary
- implement `sendTelegramMessage` utility
- notify via Telegram when free keys drop below 20
- document environment variables for Telegram
- test Telegram message function and low-key notification logic

## Testing
- `npm test` *(fails: jest not found)*