### PR TITLE
Warn on low keys during startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ Damit schreibt Pino alle Logeinträge in die angegebene Datei.
 ## Telegram-Benachrichtigung
 
 Ist ein Bot-Token sowie eine Chat-ID hinterlegt, informiert der Server per
-Telegram, sobald weniger als 20 freie Keys vorhanden sind. Dazu müssen folgende
+Telegram, sobald weniger als 20 freie Keys vorhanden sind. Dies wird sowohl
+beim laufenden Betrieb als auch direkt beim Start des Servers geprüft. Dazu müssen folgende
 Variablen gesetzt werden:
 
 ```bash

--- a/__tests__/telegram.test.js
+++ b/__tests__/telegram.test.js
@@ -55,6 +55,24 @@ describe('Telegram Integration', () => {
 
     const { app } = await createServerWithKeys(19);
     await app.inject({ method: 'PUT', url: '/keys/1/inuse', payload: {} });
+    // Ein Aufruf erfolgt bereits beim Start, ein weiterer beim Markieren des Key
+    expect(spy).toHaveBeenCalledTimes(2);
+    await app.close();
+    spy.mockRestore();
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.TELEGRAM_CHAT_ID;
+  });
+
+  test('Warnung bereits beim Start bei zu wenigen Keys', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'T';
+    process.env.TELEGRAM_CHAT_ID = 'C';
+    const spy = jest
+      .spyOn(telegram, 'sendTelegramMessage')
+      .mockResolvedValue({ ok: true });
+
+    const { app } = await createServerWithKeys(18);
+    // Kurze Pause, damit der asynchrone Aufruf verarbeitet wird
+    await new Promise((r) => setImmediate(r));
     expect(spy).toHaveBeenCalledTimes(1);
     await app.close();
     spy.mockRestore();

--- a/server.js
+++ b/server.js
@@ -69,6 +69,10 @@ async function buildServer(options = {}) {
   }
 
   await loadData();
+  // Direkt nach dem Laden der bestehenden Daten prüfen wir, ob bereits
+  // weniger als THRESHOLD freie Keys vorhanden sind. Ist dies der Fall,
+  // wird sofort eine Telegram-Warnung verschickt.
+  notifyIfLow();
 
   app.get('/keys', async (request) => {
     let result = keys;


### PR DESCRIPTION
## Summary
- warn when too few keys are available immediately after loading saved data
- update telegram tests for notification on startup
- document the Telegram check in README

## Testing
- `npm test`