### PR TITLE
Dashboard Listen nebeneinander

### DIFF
--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -42,6 +42,12 @@ describe('Dashboard', () => {
     expect(res.payload).toContain('class="result-box"');
   });
 
+  test('ordnet die Listen nebeneinander an', async () => {
+    const { app } = await createServer();
+    const res = await app.inject('/');
+    expect(res.payload).toContain('class="key-lists"');
+  });
+
 
   test('nutzt Icon-Buttons', async () => {
     const { app } = await createServer();

--- a/public/index.html
+++ b/public/index.html
@@ -37,15 +37,18 @@
         <div>Ungültige Keys: <strong id="invalidCount">0</strong></div>
       </section>
 
-      <section>
-        <h2>Freie Keys</h2>
-        <div id="listFree" class="key-list"></div>
-      </section>
+      <!-- Beide Listen nebeneinander anzeigen -->
+      <div class="key-lists">
+        <section>
+          <h2>Freie Keys</h2>
+          <div id="listFree" class="key-list"></div>
+        </section>
 
-      <section>
-        <h2>Aktivierte Keys</h2>
-        <div id="listActive" class="key-list"></div>
-      </section>
+        <section>
+          <h2>Aktivierte Keys</h2>
+          <div id="listActive" class="key-list"></div>
+        </section>
+      </div>
     </div>
 
     <!-- TAB ▸ Aktionen -->

--- a/public/style.css
+++ b/public/style.css
@@ -154,6 +154,17 @@ section h2 {
   font-size: 1.1rem;
 }
 
+/* Container für freie und aktivierte Keys nebeneinander */
+.key-lists {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.key-lists section {
+  flex: 1;
+  min-width: 240px;
+}
+
 /* Flex-Listen */
 .key-list,
 .key-actions {


### PR DESCRIPTION
## Summary
- im Dashboard die Listen der freien und aktivierten Keys nebeneinander anzeigen
- CSS-Styles für zweispaltige Darstellung ergänzt
- Test erweitert

## Testing
- `npm test`