### PR TITLE
Persist Telegram warning state

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,10 @@ Damit schreibt Pino alle Logeinträge in die angegebene Datei.
 Ist ein Bot-Token sowie eine Chat-ID hinterlegt, informiert der Server per
 Telegram, sobald erstmals weniger als 20 freie Keys vorhanden sind. Fällt der
 Bestand später unter zehn, wird ein weiteres Mal gewarnt. Diese Prüfung erfolgt
-sowohl beim laufenden Betrieb als auch direkt beim Start des Servers. Dazu müssen folgende
+sowohl beim laufenden Betrieb als auch direkt beim Start des Servers. Der zuletzt
+ausgelöste Warnstatus wird jetzt in der Datei `db.json` gespeichert, damit ein
+Neustart keine erneute Meldung erzeugt, wenn sich die Anzahl der Keys nicht
+geändert hat. Dazu müssen folgende
 Variablen gesetzt werden:
 
 ```bash
@@ -192,7 +195,8 @@ export TELEGRAM_CHAT_ID="<CHAT_ID>"
 
 Die Warnungen werden nur einmal je Schwelle versendet, um wiederholte Meldungen
 zu vermeiden. Steigt die Zahl freier Keys über zwanzig, beginnt die Zählung von
-neuem.
+neuem. Die Telegram-Nachricht enthält zusätzlich die Gesamtzahl aller Keys und
+einen Link zum Dashboard (`http://localhost:3000/`).
 
 ## Tests
 

--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -6,7 +6,7 @@ const buildServer = require('../server');
 // Hilfsfunktion zum Starten eines Servers mit temporärer Datenbank
 async function createServer() {
   const dbPath = path.join(os.tmpdir(), `db-${Date.now()}-${Math.random()}.json`);
-  await fs.writeFile(dbPath, '[]');
+  await fs.writeFile(dbPath, JSON.stringify({ lastWarned: null, keys: [] }));
   const app = await buildServer({ logger: false, dbFile: dbPath });
   return { app, dbPath };
 }

--- a/__tests__/logging.test.js
+++ b/__tests__/logging.test.js
@@ -9,7 +9,7 @@ describe('Logging in Datei', () => {
   test('schreibt Einträge in angegebene Logdatei', async () => {
     const dbPath = path.join(os.tmpdir(), `db-${Date.now()}-${Math.random()}.json`);
     const logPath = path.join(os.tmpdir(), `log-${Date.now()}-${Math.random()}.log`);
-    await fs.writeFile(dbPath, '[]');
+    await fs.writeFile(dbPath, JSON.stringify({ lastWarned: null, keys: [] }));
 
     const app = await buildServer({ logger: true, dbFile: dbPath, logFile: logPath });
 


### PR DESCRIPTION
## Summary
- persist `lastWarned` threshold in db file and load it on startup
- add free/total info and dashboard link to telegram messages
- save warn state when changed
- adjust tests for new database structure
- document changed telegram behaviour

## Testing
- `npm test`