### PR TITLE
Implement key-based API operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,17 @@ Textfeld kann zudem nach dem Wert des Feldes `assignedTo` gefiltert werden.
 Beim Klick auf **Laden** werden diese Angaben als Query-Parameter an den
 Endpunkt `/keys` angehängt und das Ergebnis direkt angezeigt.
 
-Außerdem steht ein Formular **Key freigeben** bereit. Mit Eingabe einer ID
-schickt es einen PUT-Request auf `/keys/:id/release`, markiert den Key damit als
-frei und zeigt die Antwort direkt unter dem Formular an.
+Außerdem steht ein Formular **Key freigeben** bereit. Mit Eingabe des
+Windows-Keys schickt es einen PUT-Request auf `/keys/:key/release`, markiert den
+Eintrag damit als frei und zeigt die Antwort direkt unter dem Formular an.
 
-Neu hinzugekommen ist ein weiteres Formular **Key löschen**, das eine
-ID entgegennimmt und damit einen `DELETE`-Request auf `/keys/:id` ausführt.
+Neu hinzugekommen ist ein weiteres Formular **Key löschen**, das den
+Schlüssel entgegennimmt und damit einen `DELETE`-Request auf `/keys/:key`
+ausführt.
 Das Ergebnis wird ebenfalls im Dashboard angezeigt.
 
-Ebenfalls verfügbar ist nun ein Formular **Key ungültig**, das eine ID annimmt
-und per Button einen `PUT`-Request auf `/keys/:id/invalidate` sendet. Dadurch
+Ebenfalls verfügbar ist nun ein Formular **Key ungültig**, das einen Key annimmt
+und per Button einen `PUT`-Request auf `/keys/:key/invalidate` sendet. Dadurch
 wird der gewählte Key dauerhaft als unbrauchbar markiert. Die Serverantwort wird
 unter dem Formular dargestellt.
 
@@ -121,26 +122,26 @@ Gibt eine komplette Liste aller momentan freien Keys zurück. Die Antwort ist ei
 ### GET `/keys/active/list`
 Liefert alle Keys, die aktuell in Benutzung sind (`inUse=true`). Auch hier wird ein Array von Key-Objekten zurückgegeben.
 
-### GET `/keys/:id/history`
-Gibt die komplette Historie eines Keys zurück. Die Antwort ist ein Array mit Einträgen der Form `{ action, timestamp, assignedTo }`. Ist die ID unbekannt, antwortet der Server mit Statuscode `404`.
+### GET `/keys/:key/history`
+Gibt die komplette Historie eines Keys zurück. Die Antwort ist ein Array mit Einträgen der Form `{ action, timestamp, assignedTo }`. Ist der Key unbekannt, antwortet der Server mit Statuscode `404`.
 
-### PUT `/keys/:id/inuse`
-Markiert einen Key als in Benutzung. Die ID wird in der URL angegeben. Im Request-Body kann ein Feld `assignedTo` übergeben werden, um zu notieren, wer den Key verwendet:
+### PUT `/keys/:key/inuse`
+Markiert einen Key als in Benutzung. Der Windows-Key wird in der URL angegeben. Im Request-Body kann ein Feld `assignedTo` übergeben werden, um zu notieren, wer den Key verwendet:
 ```json
 { "assignedTo": "Max" }
 ```
-Die Antwort enthält das aktualisierte Key-Objekt. Bei unbekannter ID wird ein 404-Statuscode zurückgegeben.
+Die Antwort enthält das aktualisierte Key-Objekt. Bei unbekanntem Key wird ein 404-Statuscode zurückgegeben.
 
-### PUT `/keys/:id/release`
+### PUT `/keys/:key/release`
 Setzt einen zuvor belegten Key wieder auf frei. `inUse` wird dabei auf `false` gesetzt und das Feld `assignedTo` geleert. In der History wird ein Eintrag mit der Aktion `release` und Zeitstempel gespeichert. Die Antwort enthält den aktualisierten Key.
 
-### PUT `/keys/:id/invalidate`
+### PUT `/keys/:key/invalidate`
 Markiert einen bestehenden Key dauerhaft als ungültig. Ein so gekennzeichneter
 Eintrag wird von `/keys/free` ignoriert und kann nicht mehr genutzt werden. Die
 Antwort enthält das aktualisierte Key-Objekt mit dem Feld `invalid=true`.
 
-### DELETE `/keys/:id`
-Entfernt einen Key dauerhaft aus der Datenbank. Bei Erfolg wird `{ success: true }` zurückgegeben. Ist die ID unbekannt, lautet der Statuscode `404`.
+### DELETE `/keys/:key`
+Entfernt einen Key dauerhaft aus der Datenbank. Bei Erfolg wird `{ success: true }` zurückgegeben. Ist der Key unbekannt, lautet der Statuscode `404`.
 
 ## Datenstruktur
 

--- a/__tests__/telegram.test.js
+++ b/__tests__/telegram.test.js
@@ -54,7 +54,7 @@ describe('Telegram Integration', () => {
       .mockResolvedValue({ ok: true });
 
     const { app } = await createServerWithKeys(19);
-    await app.inject({ method: 'PUT', url: '/keys/1/inuse', payload: {} });
+    await app.inject({ method: 'PUT', url: '/keys/AAAAA-BBBBB-CCCCC-DDDDD-00000/inuse', payload: {} });
     // Meldung erfolgt nur beim ersten Unterschreiten der Schwelle
     expect(spy).toHaveBeenCalledTimes(1);
     await app.close();
@@ -71,8 +71,8 @@ describe('Telegram Integration', () => {
       .mockResolvedValue({ ok: true });
 
     const { app } = await createServerWithKeys(11);
-    await app.inject({ method: 'PUT', url: '/keys/1/inuse', payload: {} });
-    await app.inject({ method: 'PUT', url: '/keys/2/inuse', payload: {} });
+    await app.inject({ method: 'PUT', url: '/keys/AAAAA-BBBBB-CCCCC-DDDDD-00000/inuse', payload: {} });
+    await app.inject({ method: 'PUT', url: '/keys/AAAAA-BBBBB-CCCCC-DDDDD-00001/inuse', payload: {} });
     // Erst beim Fallen unter zehn folgt eine zweite Warnung
     expect(spy).toHaveBeenCalledTimes(2);
     await app.close();

--- a/public/index.html
+++ b/public/index.html
@@ -81,7 +81,7 @@
       <section>
         <h2>Key als benutzt markieren</h2>
         <form id="markInUseForm">
-          <input type="number" id="keyId" placeholder="ID">
+          <input type="text" id="keyValue" placeholder="Key">
           <input type="text" id="assignedTo" placeholder="Zugewiesen an">
           <button type="submit">Markieren</button>
         </form>
@@ -91,7 +91,7 @@
       <section>
         <h2>Key freigeben</h2>
         <form id="releaseForm">
-          <input type="number" id="releaseId" placeholder="ID">
+          <input type="text" id="releaseKey" placeholder="Key">
           <button type="submit">Freigeben</button>
         </form>
         <div id="releaseResult" class="result-box"></div>
@@ -100,7 +100,7 @@
       <section>
         <h2>Key ungültig markieren</h2>
         <form id="invalidateForm">
-          <input type="number" id="invalidateId" placeholder="ID">
+          <input type="text" id="invalidateKey" placeholder="Key">
           <button type="submit">Ungültig</button>
         </form>
         <div id="invalidateResult" class="result-box"></div>
@@ -109,7 +109,7 @@
       <section>
         <h2>Key löschen</h2>
         <form id="deleteForm">
-          <input type="number" id="deleteId" placeholder="ID">
+          <input type="text" id="deleteKey" placeholder="Key">
           <button type="submit">Löschen</button>
         </form>
         <div id="deleteResult" class="result-box"></div>
@@ -207,12 +207,12 @@
       const acts=document.createElement('div'); acts.className='key-actions';
 
       acts.append(
-        createActionButton('✔️','icon-use',()=>markKeyInUse(k.id, prompt('Zugewiesen an?')||''),'Benutzen'),
-        createActionButton('↩️','icon-release',()=>releaseKey(k.id),'Freigeben'),
-        createActionButton('🚫','icon-invalidate',()=>invalidateKey(k.id),'Ungültig'),
-        createActionButton('🗑️','icon-delete',()=>deleteKey(k.id),'Löschen'),
+        createActionButton('✔️','icon-use',()=>markKeyInUse(k.key, prompt('Zugewiesen an?')||''),'Benutzen'),
+        createActionButton('↩️','icon-release',()=>releaseKey(k.key),'Freigeben'),
+        createActionButton('🚫','icon-invalidate',()=>invalidateKey(k.key),'Ungültig'),
+        createActionButton('🗑️','icon-delete',()=>deleteKey(k.key),'Löschen'),
         createActionButton('📋','icon-copy',()=>navigator.clipboard.writeText(k.key),'Kopieren'),
-        createActionButton('📜','icon-history',()=>{showHistory(k.id);document.querySelector('[data-tab="history"]').click();},'Historie')
+        createActionButton('📜','icon-history',()=>{showHistory(k.key);document.querySelector('[data-tab="history"]').click();},'Historie')
       );
       row.appendChild(acts); el.appendChild(row);
     });
@@ -221,30 +221,30 @@
   async function loadFreeList(){ renderList('listFree','/keys/free/list'); }
   async function loadActiveList(){ renderList('listActive','/keys/active/list'); }
 
-  async function markKeyInUse(id,assignedTo=''){
-    const r=await fetch(`/keys/${id}/inuse`,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({assignedTo})});
+  async function markKeyInUse(key,assignedTo=''){
+    const r=await fetch(`/keys/${key}/inuse`,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({assignedTo})});
     const d=await r.json(); displayJson('inUseResult',d);
-    updateStats(); loadFreeList(); loadActiveList(); showHistory(id);
+    updateStats(); loadFreeList(); loadActiveList(); showHistory(key);
   }
 
-  async function releaseKey(id){
-    const r=await fetch(`/keys/${id}/release`,{method:'PUT'}); const d=await r.json();
-    displayJson('releaseResult',d); updateStats(); loadFreeList(); loadActiveList(); showHistory(id);
+  async function releaseKey(key){
+    const r=await fetch(`/keys/${key}/release`,{method:'PUT'}); const d=await r.json();
+    displayJson('releaseResult',d); updateStats(); loadFreeList(); loadActiveList(); showHistory(key);
   }
 
-  async function invalidateKey(id){
-    const r=await fetch(`/keys/${id}/invalidate`,{method:'PUT'}); const d=await r.json();
-    displayJson('invalidateResult',d); updateStats(); loadFreeList(); loadActiveList(); showHistory(id);
+  async function invalidateKey(key){
+    const r=await fetch(`/keys/${key}/invalidate`,{method:'PUT'}); const d=await r.json();
+    displayJson('invalidateResult',d); updateStats(); loadFreeList(); loadActiveList(); showHistory(key);
   }
 
-  async function deleteKey(id){
-    const r=await fetch(`/keys/${id}`,{method:'DELETE'}); const d=await r.json();
+  async function deleteKey(key){
+    const r=await fetch(`/keys/${key}`,{method:'DELETE'}); const d=await r.json();
     displayJson('deleteResult',d); updateStats(); loadFreeList(); loadActiveList(); document.getElementById('historyLog').textContent='';
   }
 
-  async function showHistory(id){
-    if(!id) return;
-    const r=await fetch(`/keys/${id}/history`); const h=await r.json();
+  async function showHistory(key){
+    if(!key) return;
+    const r=await fetch(`/keys/${key}/history`); const h=await r.json();
     displayJson('historyLog',h);
   }
 
@@ -264,7 +264,7 @@
     const keys=raw.split(/\r?\n/).map(k=>k.trim()).filter(Boolean);
     const r=await fetch('/keys',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({keys})});
     const d=await r.json(); displayJson('addKeyResult',d);
-    updateStats(); loadFreeList(); loadActiveList(); if(d.length) showHistory(d[0].id);
+    updateStats(); loadFreeList(); loadActiveList(); if(d.length) showHistory(d[0].key);
   };
 
   document.getElementById('getFreeKey').onclick=async()=>{
@@ -274,12 +274,12 @@
 
   document.getElementById('markInUseForm').onsubmit=e=>{
     e.preventDefault();
-    markKeyInUse(document.getElementById('keyId').value,document.getElementById('assignedTo').value);
+    markKeyInUse(document.getElementById('keyValue').value,document.getElementById('assignedTo').value);
   };
 
-  document.getElementById('releaseForm').onsubmit=e=>{ e.preventDefault(); releaseKey(document.getElementById('releaseId').value); };
-  document.getElementById('invalidateForm').onsubmit=e=>{ e.preventDefault(); invalidateKey(document.getElementById('invalidateId').value); };
-  document.getElementById('deleteForm').onsubmit=e=>{ e.preventDefault(); deleteKey(document.getElementById('deleteId').value); };
+  document.getElementById('releaseForm').onsubmit=e=>{ e.preventDefault(); releaseKey(document.getElementById('releaseKey').value); };
+  document.getElementById('invalidateForm').onsubmit=e=>{ e.preventDefault(); invalidateKey(document.getElementById('invalidateKey').value); };
+  document.getElementById('deleteForm').onsubmit=e=>{ e.preventDefault(); deleteKey(document.getElementById('deleteKey').value); };
 
   /* ----------------- Initial Load ----------------- */
   document.addEventListener('DOMContentLoaded',()=>{

--- a/server.js
+++ b/server.js
@@ -230,10 +230,12 @@ async function buildServer(options = {}) {
     return active;
   });
 
-  app.put('/keys/:id/inuse', async (request, reply) => {
-    const id = parseInt(request.params.id, 10);
+  // Setzt einen Key anhand seines Textwerts auf "in Benutzung"
+  // Der Key selbst wird direkt in der URL angegeben
+  app.put('/keys/:key/inuse', async (request, reply) => {
+    const keyValue = request.params.key;
     const { assignedTo } = request.body || {};
-    const keyEntry = keys.find((k) => k.id === id);
+    const keyEntry = keys.find((k) => k.key === keyValue);
 
     if (!keyEntry) {
       reply.code(404);
@@ -253,14 +255,16 @@ async function buildServer(options = {}) {
     await notifyIfLow();
 
     // Meldet im Log, dass der Key nun benutzt wird
-    app.log.info({ id, assignedTo: keyEntry.assignedTo }, 'Key als benutzt markiert');
+    // Im Log wird der verwendete Key ausgegeben
+    app.log.info({ key: keyValue, assignedTo: keyEntry.assignedTo }, 'Key als benutzt markiert');
     return keyEntry;
   });
 
   // Setzt einen Key wieder auf "frei" und entfernt die Zuweisung
-  app.put('/keys/:id/release', async (request, reply) => {
-    const id = parseInt(request.params.id, 10);
-    const keyEntry = keys.find((k) => k.id === id);
+  // Auch hier wird der Key direkt als Parameter verwendet
+  app.put('/keys/:key/release', async (request, reply) => {
+    const keyValue = request.params.key;
+    const keyEntry = keys.find((k) => k.key === keyValue);
 
     if (!keyEntry) {
       reply.code(404);
@@ -276,13 +280,15 @@ async function buildServer(options = {}) {
     await saveData();
 
     // Protokolliert die Freigabe eines Keys
-    app.log.info({ id }, 'Key wieder freigegeben');
+    // Im Log den Key ausgeben
+    app.log.info({ key: keyValue }, 'Key wieder freigegeben');
     return keyEntry;
   });
 
-  app.get('/keys/:id/history', async (request, reply) => {
-    const id = parseInt(request.params.id, 10);
-    const keyEntry = keys.find((k) => k.id === id);
+  // Liefert die Historie eines bestimmten Keys
+  app.get('/keys/:key/history', async (request, reply) => {
+    const keyValue = request.params.key;
+    const keyEntry = keys.find((k) => k.key === keyValue);
     if (!keyEntry) {
       reply.code(404);
       return { error: 'Key nicht gefunden' };
@@ -292,9 +298,9 @@ async function buildServer(options = {}) {
 
   // Markiert einen Key dauerhaft als ungültig
   // Im Dashboard wird dieser Endpunkt über den Button "Key ungültig" aufgerufen
-  app.put('/keys/:id/invalidate', async (request, reply) => {
-    const id = parseInt(request.params.id, 10);
-    const keyEntry = keys.find((k) => k.id === id);
+  app.put('/keys/:key/invalidate', async (request, reply) => {
+    const keyValue = request.params.key;
+    const keyEntry = keys.find((k) => k.key === keyValue);
     if (!keyEntry) {
       reply.code(404);
       return { error: 'Key nicht gefunden' };
@@ -306,9 +312,10 @@ async function buildServer(options = {}) {
     return keyEntry;
   });
 
-  app.delete('/keys/:id', async (request, reply) => {
-    const id = parseInt(request.params.id, 10);
-    const index = keys.findIndex((k) => k.id === id);
+  // Entfernt einen Key anhand seines Textwerts dauerhaft
+  app.delete('/keys/:key', async (request, reply) => {
+    const keyValue = request.params.key;
+    const index = keys.findIndex((k) => k.key === keyValue);
     if (index === -1) {
       reply.code(404);
       return { error: 'Key nicht gefunden' };
@@ -318,7 +325,8 @@ async function buildServer(options = {}) {
     await notifyIfLow();
 
     // Loggt das Löschen eines Keys
-    app.log.info({ id }, 'Key gelöscht');
+    // Löschvorgang im Log festhalten
+    app.log.info({ key: keyValue }, 'Key gelöscht');
     return { success: true };
   });
 


### PR DESCRIPTION
## Summary
- allow key actions by value instead of ID on server side
- adjust dashboard forms and JS to use key strings
- update documentation for new endpoints
- adapt tests for key-based routes

## Testing
- `npm test` *(fails: jest not found)*