### PR TITLE
Add test guards for telegram

### DIFF
--- a/__tests__/telegram.test.js
+++ b/__tests__/telegram.test.js
@@ -48,6 +48,7 @@ describe('Telegram Integration', () => {
   test('Server benachrichtigt nur einmal unter zwanzig Keys', async () => {
     process.env.TELEGRAM_BOT_TOKEN = 'T';
     process.env.TELEGRAM_CHAT_ID = 'C';
+    process.env.SEND_TELEGRAM_DURING_TESTS = 'true';
     // Wir überwachen sendTelegramMessage, um den Aufruf zu zählen
     const spy = jest
       .spyOn(telegram, 'sendTelegramMessage')
@@ -61,11 +62,13 @@ describe('Telegram Integration', () => {
     spy.mockRestore();
     delete process.env.TELEGRAM_BOT_TOKEN;
     delete process.env.TELEGRAM_CHAT_ID;
+    delete process.env.SEND_TELEGRAM_DURING_TESTS;
   });
 
   test('Server meldet erneut bei weniger als zehn Keys', async () => {
     process.env.TELEGRAM_BOT_TOKEN = 'T';
     process.env.TELEGRAM_CHAT_ID = 'C';
+    process.env.SEND_TELEGRAM_DURING_TESTS = 'true';
     const spy = jest
       .spyOn(telegram, 'sendTelegramMessage')
       .mockResolvedValue({ ok: true });
@@ -79,11 +82,13 @@ describe('Telegram Integration', () => {
     spy.mockRestore();
     delete process.env.TELEGRAM_BOT_TOKEN;
     delete process.env.TELEGRAM_CHAT_ID;
+    delete process.env.SEND_TELEGRAM_DURING_TESTS;
   });
 
   test('Warnung bereits beim Start bei zu wenigen Keys', async () => {
     process.env.TELEGRAM_BOT_TOKEN = 'T';
     process.env.TELEGRAM_CHAT_ID = 'C';
+    process.env.SEND_TELEGRAM_DURING_TESTS = 'true';
     const spy = jest
       .spyOn(telegram, 'sendTelegramMessage')
       .mockResolvedValue({ ok: true });
@@ -96,11 +101,13 @@ describe('Telegram Integration', () => {
     spy.mockRestore();
     delete process.env.TELEGRAM_BOT_TOKEN;
     delete process.env.TELEGRAM_CHAT_ID;
+    delete process.env.SEND_TELEGRAM_DURING_TESTS;
   });
 
   test('Warnstatus bleibt nach Neustart erhalten', async () => {
     process.env.TELEGRAM_BOT_TOKEN = 'T';
     process.env.TELEGRAM_CHAT_ID = 'C';
+    process.env.SEND_TELEGRAM_DURING_TESTS = 'true';
     const spy = jest
       .spyOn(telegram, 'sendTelegramMessage')
       .mockResolvedValue({ ok: true });
@@ -117,12 +124,14 @@ describe('Telegram Integration', () => {
     spy.mockRestore();
     delete process.env.TELEGRAM_BOT_TOKEN;
     delete process.env.TELEGRAM_CHAT_ID;
+    delete process.env.SEND_TELEGRAM_DURING_TESTS;
   });
 
 
   test('Telegram-Nachricht enthält nur die Zahl freier Keys', async () => {
     process.env.TELEGRAM_BOT_TOKEN = 'T';
     process.env.TELEGRAM_CHAT_ID = 'C';
+    process.env.SEND_TELEGRAM_DURING_TESTS = 'true';
     const spy = jest
       .spyOn(telegram, 'sendTelegramMessage')
       .mockResolvedValue({ ok: true });
@@ -134,6 +143,23 @@ describe('Telegram Integration', () => {
       'C',
       'Warnung: Nur noch 18 freie Keys. Zum Dashboard: http://localhost:3000/'
     );
+    await app.close();
+    spy.mockRestore();
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.TELEGRAM_CHAT_ID;
+    delete process.env.SEND_TELEGRAM_DURING_TESTS;
+  });
+
+  test('verschickt im Testmodus keine Nachricht ohne Freigabe', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'T';
+    process.env.TELEGRAM_CHAT_ID = 'C';
+    const spy = jest
+      .spyOn(telegram, 'sendTelegramMessage')
+      .mockResolvedValue({ ok: true });
+
+    const { app } = await createServerWithKeys(19);
+    await app.inject({ method: 'PUT', url: '/keys/AAAAA-BBBBB-CCCCC-DDDDD-00000/inuse', payload: {} });
+    expect(spy).not.toHaveBeenCalled();
     await app.close();
     spy.mockRestore();
     delete process.env.TELEGRAM_BOT_TOKEN;

--- a/server.js
+++ b/server.js
@@ -48,6 +48,22 @@ async function buildServer(options = {}) {
 
     for (const limit of THRESHOLDS) {
       if (free < limit && limit < lastWarned) {
+        // ***
+        // Bevor wir eine Telegram-Nachricht verschicken, prüfen wir, ob wir
+        // uns gerade im Testbetrieb befinden. Standardmäßig sollen während der
+        // Jest-Tests keine Nachrichten versendet werden, um unnötige Aufrufe
+        // und Abhängigkeiten zu vermeiden. Nur wenn explizit die Variable
+        // SEND_TELEGRAM_DURING_TESTS auf "true" gesetzt ist, wird der Versand
+        // zugelassen. Andernfalls kehren wir einfach zurück und überspringen
+        // den Aufruf von sendTelegramMessage.
+        // ***
+        if (
+          process.env.NODE_ENV === 'test' &&
+          process.env.SEND_TELEGRAM_DURING_TESTS !== 'true'
+        ) {
+          return;
+        }
+
         // Fehler beim Senden dürfen den Server nicht stoppen
         telegram
           .sendTelegramMessage(
@@ -57,7 +73,7 @@ async function buildServer(options = {}) {
             // Die Nachricht nennt nur noch die verbleibenden freien Keys
             `Warnung: Nur noch ${free} freie Keys. ` +
 
-  
+
               'Zum Dashboard: http://localhost:3000/'
           )
           .catch(() => {});


### PR DESCRIPTION
## Summary
- skip telegram notifications during tests unless explicitly allowed
- extend telegram tests to toggle SEND_TELEGRAM_DURING_TESTS
- add regression test for suppressed notifications

## Testing
- `npm test`