### PR TITLE
Add configurable Telegram settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ neuem. Die Telegram-Nachricht gibt nur noch die Anzahl der aktuell freien Keys
 an und enthält einen Link zum Dashboard
 (`http://localhost:3000/`).
 
+Die Schwellenwerte sowie der Nachrichtentext können über die Endpunkte
+`GET /telegram/settings` und `PUT /telegram/settings` angepasst werden. Die
+PUT-Variante erwartet ein JSON-Objekt mit den Feldern `thresholds` (Array von
+Zahlen) und `messageTemplate`. In letzterem wird die Platzhaltervariable
+`{free}` durch die aktuelle Zahl freier Keys ersetzt.
+
 
 ## Tests
 

--- a/public/index.html
+++ b/public/index.html
@@ -106,6 +106,16 @@
         </form>
         <div id="deleteResult" class="result-box"></div>
       </section>
+
+      <section>
+        <h2>Telegram Einstellungen</h2>
+        <form id="telegramForm">
+          <input type="text" id="thresholdInput" placeholder="20,10">
+          <textarea id="messageTemplate" rows="2" placeholder="Nachricht"></textarea>
+          <button type="submit">Speichern</button>
+        </form>
+        <div id="telegramResult" class="result-box"></div>
+      </section>
     </div>
 
     <!-- TAB ▸ Historie -->
@@ -302,11 +312,30 @@
   document.getElementById('releaseForm').onsubmit=e=>{ e.preventDefault(); releaseKey(document.getElementById('releaseKey').value); };
   document.getElementById('deleteForm').onsubmit=e=>{ e.preventDefault(); deleteKey(document.getElementById('deleteKey').value); };
 
+  // Lädt Schwellenwerte und Nachrichtentext
+  async function loadTelegram(){
+    const r=await fetch('/telegram/settings');
+    const cfg=await r.json();
+    document.getElementById('thresholdInput').value=cfg.thresholds.join(',');
+    document.getElementById('messageTemplate').value=cfg.messageTemplate;
+  }
+
+  // Speichert Änderungen an den Telegram-Einstellungen
+  document.getElementById('telegramForm').onsubmit=async e=>{
+    e.preventDefault();
+    const th=document.getElementById('thresholdInput').value
+      .split(',').map(t=>parseInt(t,10)).filter(n=>!isNaN(n));
+    const msg=document.getElementById('messageTemplate').value;
+    const r=await fetch('/telegram/settings',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({thresholds:th,messageTemplate:msg})});
+    const d=await r.json();
+    displayJson('telegramResult',d);
+  };
+
   /* ----------------- Initial Load ----------------- */
   document.addEventListener('DOMContentLoaded',()=>{
     applyTheme(localStorage.getItem('theme'));
     sidebar.classList.toggle('hidden', window.innerWidth < 850);  /* mobile default-closed */
-    updateStats(); loadFreeList(); loadActiveList(); loadGlobalHistory();
+    updateStats(); loadFreeList(); loadActiveList(); loadGlobalHistory(); loadTelegram();
   });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- load Telegram config from db and allow customizing threshold and message
- implement REST endpoints to read/update the config
- add form on dashboard for editing Telegram settings
- document new feature in README
- test GET/PUT /telegram/settings endpoints

## Testing
- `npm test`