### PR TITLE
Darkmode Variablen und Test

### DIFF
--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -143,6 +143,17 @@ describe('Dashboard', () => {
     expect(dom.window.document.getElementById('themeToggle').textContent).toContain('☀️');
   });
 
+  test('applyTheme setzt die Hintergrundvariable im Darkmode', async () => {
+    const html = await fs.readFile(path.join(__dirname, '../public/index.html'), 'utf8');
+    const { JSDOM } = require('../test-utils/fake-dom');
+    const dom = new JSDOM(html, { runScripts: 'dangerously' });
+
+    dom.window.applyTheme('dark');
+
+    expect(dom.window.document.body.style.getPropertyValue('--bg'))
+      .toBe('hsl(222 28% 10%)');
+  });
+
   test('showFreeKey erzeugt einen Kopieren-Button', async () => {
     const html = await fs.readFile(path.join(__dirname, '../public/index.html'), 'utf8');
     const { JSDOM } = require('../test-utils/fake-dom');

--- a/public/index.html
+++ b/public/index.html
@@ -138,6 +138,20 @@
   function applyTheme(mode){
     document.body.classList.remove('light','dark');
     if (mode) document.body.classList.add(mode);
+
+    // Setzt die Farbvariablen entsprechend dem ausgewählten Modus
+    if(mode === 'dark'){
+      document.body.style.setProperty('--bg','hsl(222 28% 10%)');
+      document.body.style.setProperty('--text','hsl(0 0% 92%)');
+      document.body.style.setProperty('--border','hsl(0 0% 25%)');
+      document.body.style.setProperty('--card','hsl(222 28% 14%)');
+    } else if(mode === 'light'){
+      document.body.style.setProperty('--bg','hsl(0 0% 99%)');
+      document.body.style.setProperty('--text','hsl(0 0% 18%)');
+      document.body.style.setProperty('--border','hsl(0 0% 85%)');
+      document.body.style.setProperty('--card','#fff');
+    }
+
     themeToggle.textContent = mode === 'dark' ? '☀️' : '🌙';
   }
 

--- a/public/style.css
+++ b/public/style.css
@@ -34,6 +34,20 @@
   }
 }
 
+/* Farbvariablen für manuelles Umschalten */
+body.dark {
+  --bg: hsl(222 28% 10%);
+  --text: hsl(0 0% 92%);
+  --border: hsl(0 0% 25%);
+  --card: hsl(222 28% 14%);
+}
+body.light {
+  --bg: hsl(0 0% 99%);
+  --text: hsl(0 0% 18%);
+  --border: hsl(0 0% 85%);
+  --card: #fff;
+}
+
 /* Manuell erzwingbarer Dark / Light Mode */
 body.dark  { color-scheme: dark; }
 body.light { color-scheme: light; }

--- a/test-utils/fake-dom.js
+++ b/test-utils/fake-dom.js
@@ -16,6 +16,12 @@ class Element {
     this.className = '';
     this.title = '';
     this.children = [];
+    // Ermöglicht das Speichern von Inline-Styles inklusive CSS-Variablen
+    this.style = {
+      _v: {},
+      setProperty: (n,v)=>{ this.style._v[n]=v; },
+      getPropertyValue: (n)=>this.style._v[n]||''
+    };
     // Speichert hinterlegte Event-Handler
     this.listeners = {};
     // Einfache Umsetzung von classList 


### PR DESCRIPTION
## Summary
- erweitere CSS um Farbvariablen fuer Dark/Light Mode
- setze Variablen im Script fuer `applyTheme`
- ergaenze Fake-DOM um Style-Objekt
- neuer Jest-Test prueft die Hintergrundvariable

## Testing
- `npm test`