### PR TITLE
Implement clipboard helper and update tests

### DIFF
--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -167,6 +167,19 @@ describe('Dashboard', () => {
     expect(box.children[1].textContent).toBe('📋');
   });
 
+  test('copyKey nutzt clipboard.writeText mit korrektem Text', async () => {
+    const html = await fs.readFile(path.join(__dirname, '../public/index.html'), 'utf8');
+    const { JSDOM } = require('../test-utils/fake-dom');
+    const dom = new JSDOM(html, { runScripts: 'dangerously' });
+
+    const spy = jest.fn().mockResolvedValue();
+    dom.window.navigator.clipboard.writeText = spy;
+    await dom.window.copyKey('TESTKEY');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('TESTKEY');
+  });
+
   test('loadStats ruft /stats auf und füllt die Tabelle', async () => {
     const html = await fs.readFile(path.join(__dirname, '../public/index.html'), 'utf8');
     const { JSDOM } = require('../test-utils/fake-dom');

--- a/public/index.html
+++ b/public/index.html
@@ -251,11 +251,33 @@
     b.onclick=cb; return b;
   }
 
+  /**
+   * Kopiert den gegebenen Text in die Zwischenablage.
+   *
+   * Zuerst wird versucht, die moderne Clipboard-API zu verwenden. Sollte dies
+   * scheitern (beispielsweise in \xE4lteren Browsern), wird ein unsichtbares
+   * Textfeld erstellt, dessen Inhalt markiert und anschlie\xDFend mittels
+   * `document.execCommand('copy')` kopiert wird. Nach dem Vorgang wird das
+   * Hilfselement direkt wieder entfernt.
+   */
+  async function copyKey(text){
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (err) {
+      const ta=document.createElement('textarea');
+      ta.value=text;
+      document.body.appendChild(ta);
+      ta.select();
+      try{ document.execCommand('copy'); }catch(e){}
+      document.body.removeChild(ta);
+    }
+  }
+
   function showFreeKey(txt){
     const box=document.getElementById('freeKey'); box.innerHTML='';
     if(!txt) return;
     const span=document.createElement('span'); span.textContent=txt;
-    const copy=createActionButton('📋','icon-copy',()=>navigator.clipboard.writeText(txt),'Kopieren');
+    const copy=createActionButton('📋','icon-copy',()=>copyKey(txt),'Kopieren');
     box.append(span,copy);
   }
 
@@ -279,7 +301,7 @@
         createActionButton('✔️','icon-use',()=>markKeyInUse(k.key, prompt('Zugewiesen an?')||''),'Benutzen'),
         createActionButton('↩️','icon-release',()=>releaseKey(k.key),'Freigeben'),
         createActionButton('🗑️','icon-delete',()=>deleteKey(k.key),'Löschen'),
-        createActionButton('📋','icon-copy',()=>navigator.clipboard.writeText(k.key),'Kopieren'),
+        createActionButton('📋','icon-copy',()=>copyKey(k.key),'Kopieren'),
         createActionButton('📜','icon-history',()=>{showHistory(k.key);document.querySelector('[data-tab="history"]').click();},'Historie')
       );
       row.appendChild(acts); el.appendChild(row);


### PR DESCRIPTION
## Summary
- add `copyKey` helper in dashboard to reliably copy keys to clipboard
- replace direct `navigator.clipboard.writeText` calls with `copyKey`
- test that `copyKey` uses the clipboard API

## Testing
- `npm test`