### PR TITLE
Behebe doppelte History-Funktion im Dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -144,6 +144,7 @@
   const sidebarToggle = document.getElementById('sidebarToggle');
   const sidebar       = document.getElementById('sidebar');
 
+  // Passt das Erscheinungsbild an (Hell-/Dunkelmodus)
   function applyTheme(mode){
     document.body.classList.remove('light','dark');
     if (mode) document.body.classList.add(mode);
@@ -192,6 +193,7 @@
   });
 
   /* ----------------- Helper ----------------- */
+  // Gibt JSON-Daten formatiert im angegebenen Element aus
   function displayJson(id,obj){
     const box=document.getElementById(id);
     box.innerHTML='';
@@ -244,6 +246,7 @@
     box.appendChild(makeTable('Woche',data.perWeek));
   }
 
+  // Erstellt einen Icon-Button und verbindet ihn mit einer Aktion
   function createActionButton(icon,cls,cb,title){
     const b=document.createElement('button');
     b.className='icon-button '+cls; b.textContent=icon;
@@ -273,6 +276,7 @@
     }
   }
 
+  // Zeigt einen freien Key mit Kopierfunktion an
   function showFreeKey(txt){
     const box=document.getElementById('freeKey'); box.innerHTML='';
     if(!txt) return;
@@ -282,6 +286,7 @@
   }
 
   /* ----------------- API Operations ----------------- */
+  // Aktualisiert die Zu00e4hler fu00fcr freie, benutzte und ungu00fcltige Keys
   async function updateStats(){
     const res=await fetch('/keys'); const data=await res.json();
     document.getElementById('freeCount').textContent = data.filter(k=>!k.inUse).length;
@@ -289,6 +294,7 @@
     document.getElementById('invalidCount').textContent = data.filter(k=>k.invalid).length;
   }
 
+  // Fu00fcllt eine Liste im Dashboard mit Daten von der angegebenen URL
   async function renderList(elId,url){
     const res=await fetch(url); const data=await res.json();
     const el=document.getElementById(elId); el.innerHTML='';
@@ -308,31 +314,38 @@
     });
   }
 
+  // Listet alle freien Keys auf
   async function loadFreeList(){ renderList('listFree','/keys/free/list'); }
+  // Zeigt die aktuell benutzten Keys
   async function loadActiveList(){ renderList('listActive','/keys/active/list'); }
+  // Ruft Statistiken zu den Aktivierungen ab
   async function loadStats(){
     const r=await fetch('/stats');
     const d=await r.json();
     renderStats(d);
   }
 
+  // Markiert einen Key als in Benutzung
   async function markKeyInUse(key,assignedTo=''){
     const r=await fetch(`/keys/${key}/inuse`,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({assignedTo})});
     const d=await r.json(); displayJson('inUseResult',d);
     updateStats(); loadFreeList(); loadActiveList(); showHistory(key); loadGlobalHistory(); loadStats();
   }
 
+  // Gibt einen Key wieder frei
   async function releaseKey(key){
     const r=await fetch(`/keys/${key}/release`,{method:'PUT'}); const d=await r.json();
     displayJson('releaseResult',d); updateStats(); loadFreeList(); loadActiveList(); showHistory(key); loadGlobalHistory();
   }
 
 
+  // Lu00f6scht einen Key dauerhaft
   async function deleteKey(key){
     const r=await fetch(`/keys/${key}`,{method:'DELETE'}); const d=await r.json();
     displayJson('deleteResult',d); updateStats(); loadFreeList(); loadActiveList(); document.getElementById('historyLog').textContent=''; loadGlobalHistory();
   }
 
+  // Zeigt die Historie eines einzelnen Keys
   async function showHistory(key){
     if(!key) return;
     const r=await fetch(`/keys/${key}/history`); const h=await r.json();
@@ -346,12 +359,6 @@
     renderHistory(h);
   }
 
-  // Ruft die komplette Historie aller Keys ab und zeigt sie im Log-Bereich an
-  async function loadGlobalHistory(){
-    const r=await fetch('/history');
-    const h=await r.json();
-    displayJson('historyLog',h);
-  }
 
   /* ----------------- Form Events ----------------- */
   document.getElementById('loadKeys').onclick=async()=>{


### PR DESCRIPTION
## Summary
- entferne doppelte `loadGlobalHistory`-Funktion
- kommentiere alle Dashboard-Funktionen

## Testing
- `npm test`