### PR TITLE
README zu Telegram um .env-Hinweis ergänzt

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,24 @@ export TELEGRAM_BOT_TOKEN="<TOKEN>"
 export TELEGRAM_CHAT_ID="<CHAT_ID>"
 ```
 
+Die beiden Variablen k\xC3\B6nnen entweder wie oben gezeigt tempor\xC3\A4r in der
+Shell gesetzt oder in einer Datei `.env` hinterlegt werden. Legt man in dieser
+Datei folgende Zeilen ab,
+
+```bash
+TELEGRAM_BOT_TOKEN=<TOKEN>
+TELEGRAM_CHAT_ID=<CHAT_ID>
+```
+
+k\xC3\B6nnen die Eintr\xC3\A4ge vor dem Start des Servers geladen werden, zum
+Beispiel unter Bash mit:
+
+```bash
+export $(grep -v '^#' .env | xargs)
+```
+
+Danach steht `npm start` die Konfiguration zur Verf\xC3\BCgung.
+
 Die Warnungen werden nur einmal je Schwelle versendet, um wiederholte Meldungen
 zu vermeiden. Steigt die Zahl freier Keys über zwanzig, beginnt die Zählung von
 


### PR DESCRIPTION
## Summary
- ergänze Beschreibung zum Anlegen der Telegram-Variablen
- erkläre Nutzung einer `.env`-Datei

## Testing
- `npm test`