### PR TITLE
Add server test button in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,17 @@ zus\xe4tzliche Endpunkte:
 
 Im Dashboard k\xf6nnen so Updates angezeigt und per Klick installiert werden.
 
+### Servertests ausf\xfchren
+
+Neben den Update-Funktionen gibt es einen weiteren Endpunkt, um direkt \xfcber
+das Dashboard die Tests zu starten:
+
+- **POST `/tests/run`** startet `npm test` und liefert die Konsolenausgabe als
+  JSON-Objekt zur\xfcck.
+
+Im Dashboard findet sich dazu ein eigener Button "Ausf\xfchren" im Abschnitt
+**Tests**, der das Ergebnis anzeigt.
+
 
 ## Tests
 

--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -63,6 +63,12 @@ describe('Dashboard', () => {
     expect(res.payload).toContain('id="applyUpdates"');
   });
 
+  test('zeigt Test-Button', async () => {
+    const { app } = await createServer();
+    const res = await app.inject('/');
+    expect(res.payload).toContain('id="runTests"');
+  });
+
   test('createActionButton setzt optionalen Titel', async () => {
     const { app } = await createServer();
     const res = await app.inject('/');

--- a/__tests__/updates.test.js
+++ b/__tests__/updates.test.js
@@ -4,7 +4,8 @@ const fs = require('fs/promises');
 
 jest.mock('../update', () => ({
   getAvailableUpdates: jest.fn(async () => ['fix bug', 'add feature']),
-  applyUpdates: jest.fn(async () => ({ pull: 'ok', test: 'passed' }))
+  applyUpdates: jest.fn(async () => ({ pull: 'ok', test: 'passed' })),
+  runTests: jest.fn(async () => ({ test: 'passed' }))
 }));
 
 const buildServer = require('../server');
@@ -37,6 +38,16 @@ describe('Update Endpunkte', () => {
     expect(obj.pull).toBe('ok');
     expect(obj.test).toBe('passed');
     expect(update.applyUpdates).toHaveBeenCalled();
+    await app.close();
+  });
+
+  test('POST /tests/run ruft runTests auf', async () => {
+    const { app } = await createServer();
+    const res = await app.inject({ method: 'POST', url: '/tests/run' });
+    expect(res.statusCode).toBe(200);
+    const obj = JSON.parse(res.payload);
+    expect(obj.test).toBe('passed');
+    expect(update.runTests).toHaveBeenCalled();
     await app.close();
   });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -114,6 +114,12 @@
         <button id="applyUpdates">Installieren</button>
         <div id="updateResult" class="result-box"></div>
       </section>
+
+      <section>
+        <h2>Tests</h2>
+        <button id="runTests">Ausführen</button>
+        <div id="testResult" class="result-box"></div>
+      </section>
     </div>
 
     <!-- TAB ▸ Historie -->
@@ -370,6 +376,13 @@
     displayJson('updateResult',d);
   }
 
+  // Startet die Tests des Servers und zeigt die Ausgabe an
+  async function runTests(){
+    const r=await fetch('/tests/run',{method:'POST'});
+    const d=await r.json();
+    displayJson('testResult',d);
+  }
+
 
   /* ----------------- Form Events ----------------- */
   document.getElementById('addKeyForm').onsubmit=async e=>{
@@ -395,6 +408,7 @@
   document.getElementById('deleteForm').onsubmit=e=>{ e.preventDefault(); deleteKey(document.getElementById('deleteKey').value); };
   document.getElementById('checkUpdates').onclick=checkUpdates;
   document.getElementById('applyUpdates').onclick=runUpdates;
+  document.getElementById('runTests').onclick=runTests;
 
   // Lädt Schwellenwerte und Nachrichtentext
   async function loadTelegram(){

--- a/server.js
+++ b/server.js
@@ -427,6 +427,12 @@ async function buildServer(options = {}) {
     return result;
   });
 
+  // Führt die im Projekt hinterlegten Tests aus
+  app.post('/tests/run', async () => {
+    const result = await require('./update').runTests();
+    return result;
+  });
+
   return app;
 }
 

--- a/update.js
+++ b/update.js
@@ -38,4 +38,17 @@ async function applyUpdates() {
   return result;
 }
 
-module.exports = { getAvailableUpdates, applyUpdates };
+/**
+ * Startet ausschließlich die Tests ohne einen vorherigen Git-Pull.
+ * Die Konsolenausgabe von "npm test" wird als Ergebnis geliefert.
+ */
+async function runTests() {
+  try {
+    const { stdout } = await execAsync('npm test --silent');
+    return { test: stdout.trim() };
+  } catch (err) {
+    return { test: (err.stdout || err.message || '').trim() };
+  }
+}
+
+module.exports = { getAvailableUpdates, applyUpdates, runTests };


### PR DESCRIPTION
## Summary
- expose new `/tests/run` endpoint
- implement runTests helper to execute `npm test`
- integrate test execution into dashboard
- document new capability in README
- cover feature with new Jest tests

## Testing
- `npm test --silent`